### PR TITLE
Add floating number type

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,37 +93,40 @@ $ pmlc example.ml -t
 ### BNF
 
 ```
-expr   ::= id |
-           int |
-           bool |
-           "[]" |
-           expr expr |
-           unop expr |
-           expr binop expr |
-           expr "::" expr |
-           "if" expr "then" expr "else" expr |
-           "match" expr "with" clause |
-           "fun" id "->" expr |
-           "let" id "=" expr "in" expr |
-           "let" "rec" id "=" "fun" id "->" expr "in" expr
+expr    ::= id |
+            int |
+            decimal |
+            bool |
+            "[]" |
+            expr expr |
+            unop expr |
+            expr binop expr |
+            expr "::" expr |
+            "if" expr "then" expr "else" expr |
+            "match" expr "with" clause |
+            "fun" id "->" expr |
+            "let" id "=" expr "in" expr |
+            "let" "rec" id "=" "fun" id "->" expr "in" expr
 
-clause ::= pat "->" expr | pat "->" expr "|" clause
+clause  ::= pat "->" expr | pat "->" expr "|" clause
 
-pat    ::= id | "[]" | "_" | pat "::" pat
+pat     ::= id | "[]" | "_" | pat "::" pat
 
-id     ::= (letter | "_"){ letter | digit | "_" | "'" }
+id      ::= (letter | "_"){ letter | digit | "_" | "'" }
 
-unop   ::= "-"
+unop    ::= "-" | "-."
 
-binop  ::= "+" | "-" | "*" | "<" | ">" | "<=" | ">=" | "==" | "!=" | "&&" | "||"
+binop   ::= "+" | "-" | "*" | +." | "-." | "*." | "<" | ">" | "<=" | ">=" | "==" | "!=" | "&&" | "||"
 
-bool   ::= "true" | "false"
+bool    ::= "true" | "false"
 
-int    ::= (digit)+
+int     ::= (digit)+
 
-letter ::= "a" | ... | "z" | "A" | ... | "Z"
+decimal ::= digit+"."digit*
 
-digit  ::= "0" | ... | "9"
+letter  ::= "a" | ... | "z" | "A" | ... | "Z"
+
+digit   ::= "0" | ... | "9"
 ```
 
 ## License

--- a/playground/src/components/evaluated-log/index.tsx
+++ b/playground/src/components/evaluated-log/index.tsx
@@ -16,9 +16,13 @@ type LogMessage =
       readonly value: ValueTypeTree;
     };
 
+const floatFormatter = new Intl.NumberFormat(undefined, { useGrouping: false, minimumFractionDigits: 1 });
+
 function EvaluatedValueNode({ node }: { node: ValueTypeTree }): React.ReactElement | null {
   if (node.kind === "Int") {
     return <span className={styles.intNode}>{`${node.value}`}</span>;
+  } else if (node.kind === "Float") {
+    return <span className={styles.intNode}>{`${floatFormatter.format(node.value)}`}</span>;
   } else if (node.kind === "Bool") {
     return <span className={styles.boolNode}>{`${node.value}`}</span>;
   } else if (node.kind === "List") {

--- a/playground/src/service/program.ts
+++ b/playground/src/service/program.ts
@@ -18,10 +18,12 @@ import {
   pos2location,
   toBoolean,
   toNumber,
+  toFloat,
   toList,
   IntType,
-  ListType,
+  FloatType,
   BoolType,
+  ListType,
   FunctionType,
   TypeParameterType,
 } from "pico-ml";
@@ -36,6 +38,10 @@ export interface Diagnostic {
 }
 
 type IntValueType = IntType & {
+  value: number;
+};
+
+type FloatValueType = FloatType & {
   value: number;
 };
 
@@ -55,11 +61,19 @@ type TypeValueType = TypeParameterType & {
   value: string;
 };
 
-export type ValueTypeTree = IntValueType | BoolValueType | ListValueType | FunctionValueType | TypeValueType;
+export type ValueTypeTree =
+  | IntValueType
+  | FloatValueType
+  | BoolValueType
+  | ListValueType
+  | FunctionValueType
+  | TypeValueType;
 
 function createFormatter(instance: WebAssembly.Instance, pt: TypeValue): (value: number) => ValueTypeTree {
   if (pt.kind === "Int") {
     return (value: number) => ({ ...pt, value: toNumber(instance, value) });
+  } else if (pt.kind === "Float") {
+    return (value: number) => ({ ...pt, value: toFloat(instance, value) });
   } else if (pt.kind === "Bool") {
     return (value: number) => ({ ...pt, value: toBoolean(instance, value) });
   } else if (pt.kind === "List") {

--- a/src/cli/repl.ts
+++ b/src/cli/repl.ts
@@ -21,6 +21,8 @@ function createCommands(rl: readline.Interface) {
   const examples: string[][] = [
     ["1 + 1 ;;"],
     ["1 < 2 ;;"],
+    ["3.14 ;;"],
+    ["2.0 *. 1.5 ;;"],
     ["true != false ;;"],
     ["if 2 * 2 < 3 then true else false ;;"],
     ["fun x -> x ;;"],

--- a/src/compiler/assets/modules/alloc.ts
+++ b/src/compiler/assets/modules/alloc.ts
@@ -29,7 +29,7 @@ export function getAllocatorModuleDefinition() {
 
 export function mallocInstr(byteLength: number) {
   return [
-    factory.numericInstr("i32.const", [factory.int32(byteLength)]),
+    factory.int32NumericInstr("i32.const", [factory.int32(byteLength)]),
     factory.controlInstr("call", [factory.identifier("__malloc__")]),
   ];
 }

--- a/src/compiler/assets/modules/comparator.test.ts
+++ b/src/compiler/assets/modules/comparator.test.ts
@@ -1,0 +1,215 @@
+import { generateBinaryWithDefaultOptions as generateBinary } from "../../../wasm";
+import { ModuleBuilder } from "../../module-builder";
+import { getComparatorModuleDefinition } from "./comparator";
+import { fromNumber2IntBase, toBoolean } from "../../js-bindings";
+
+describe(getComparatorModuleDefinition, () => {
+  describe("with integer operand", () => {
+    it("should calc lt correctly", async () => {
+      expect(await compInt(1, "lt", 1)).toBe(false);
+      expect(await compInt(1, "lt", 0)).toBe(false);
+      expect(await compInt(1, "lt", 2)).toBe(true);
+    });
+  });
+
+  describe("boolean comparison", () => {
+    it("should calc lt correctly", async () => {
+      expect(await compBool(false, "lt", false)).toBe(false);
+      expect(await compBool(true, "lt", true)).toBe(false);
+      expect(await compBool(true, "lt", false)).toBe(false);
+      expect(await compBool(false, "lt", true)).toBe(true);
+    });
+  });
+
+  describe("with floating-number comparison", () => {
+    it("should calc lt correctly", async () => {
+      expect(await compFloat(0.0, "lt", 0.0)).toBe(false);
+      expect(await compFloat(1.0, "lt", 0.0)).toBe(false);
+      expect(await compFloat(0.0, "lt", 1.0)).toBe(true);
+    });
+  });
+
+  describe("with list comparison", () => {
+    test("1::[] < [] = false", async () => {
+      expect(
+        await compWithModuleCode(
+          `
+            (module
+              (func $test (result i32)
+                ;; L1
+                call $__list_new__
+                i32.const 1
+                call $__list_push__
+
+                ;; L2
+                call $__list_new__
+
+                call $__comparator_poly_lt__
+              )
+              (export "test" (func $test))
+            )
+          `,
+        ),
+      ).toBe(false);
+    });
+
+    test("1::[] < 1::[] = false", async () => {
+      expect(
+        await compWithModuleCode(
+          `
+            (module
+              (func $test (result i32)
+                ;; L1
+                call $__list_new__
+                i32.const 1
+                call $__list_push__
+
+                ;; L2
+                call $__list_new__
+                i32.const 1
+                call $__list_push__
+
+                call $__comparator_poly_lt__
+              )
+              (export "test" (func $test))
+            )
+          `,
+        ),
+      ).toBe(false);
+    });
+
+    test("[] < 1::[] = true", async () => {
+      expect(
+        await compWithModuleCode(
+          `
+            (module
+              (func $test (result i32)
+                ;; L1
+                call $__list_new__
+
+                ;; L2
+                call $__list_new__
+                i32.const 1
+                call $__list_push__
+
+                call $__comparator_poly_lt__
+              )
+              (export "test" (func $test))
+            )
+          `,
+        ),
+      ).toBe(true);
+    });
+
+    test("1::2::[] < 2::[] = true", async () => {
+      expect(
+        await compWithModuleCode(
+          `
+            (module
+              (func $test (result i32)
+                ;; L1
+                call $__list_new__
+                i32.const 2
+                call $__list_push__
+                i32.const 1
+                call $__list_push__
+
+                ;; L2
+                call $__list_new__
+                i32.const 2
+                call $__list_push__
+
+                call $__comparator_poly_lt__
+              )
+              (export "test" (func $test))
+            )
+          `,
+        ),
+      ).toBe(true);
+    });
+  });
+});
+
+async function compInt(left: number, op: "lt" | "le" | "gt" | "ge", right: number) {
+  const buf = new ModuleBuilder({
+    name: "test",
+    code: `
+        (module
+          (func $test (param $a i32) (param $b i32) (result i32)
+            local.get $a
+            local.get $b
+            call $__comparator_poly_${op}__
+          )
+          (export "test" (func $test))
+        )
+      `,
+    dependencies: [getComparatorModuleDefinition({ withFloat: true, withList: false })],
+  })
+    .build()
+    .mapValue(generateBinary)
+    .unwrap();
+  const { instance } = await WebAssembly.instantiate(buf, {});
+  return toBoolean(
+    instance,
+    (instance.exports["test"] as Function)(fromNumber2IntBase(left), fromNumber2IntBase(right)),
+  );
+}
+
+async function compBool(left: boolean, op: "lt" | "le" | "gt" | "ge", right: boolean) {
+  const buf = new ModuleBuilder({
+    name: "test",
+    code: `
+        (module
+          (func $test (param $a i32) (param $b i32) (result i32)
+            local.get $a
+            local.get $b
+            call $__comparator_poly_${op}__
+          )
+          (export "test" (func $test))
+        )
+      `,
+    dependencies: [getComparatorModuleDefinition({ withFloat: true, withList: false })],
+  })
+    .build()
+    .mapValue(generateBinary)
+    .unwrap();
+  const { instance } = await WebAssembly.instantiate(buf, {});
+  return toBoolean(instance, (instance.exports["test"] as Function)(left ? 1 : 0, right ? 1 : 0));
+}
+
+async function compFloat(left: number, op: "lt" | "le" | "gt" | "ge", right: number) {
+  const buf = new ModuleBuilder({
+    name: "test",
+    code: `
+        (module
+          (func $test (param $a f64) (param $b f64) (result i32)
+            local.get $a
+            call $__float_new__
+            local.get $b
+            call $__float_new__
+            call $__comparator_poly_${op}__
+          )
+          (export "test" (func $test))
+        )
+      `,
+    dependencies: [getComparatorModuleDefinition({ withFloat: true, withList: false })],
+  })
+    .build()
+    .mapValue(generateBinary)
+    .unwrap();
+  const { instance } = await WebAssembly.instantiate(buf, {});
+  return toBoolean(instance, (instance.exports["test"] as Function)(left ? 1 : 0, right ? 1 : 0));
+}
+
+async function compWithModuleCode(code: string) {
+  const buf = new ModuleBuilder({
+    name: "test",
+    code,
+    dependencies: [getComparatorModuleDefinition({ withFloat: true, withList: false })],
+  })
+    .build()
+    .mapValue(generateBinary)
+    .unwrap();
+  const { instance } = await WebAssembly.instantiate(buf, {});
+  return toBoolean(instance, (instance.exports["test"] as Function)());
+}

--- a/src/compiler/assets/modules/comparator.test.ts
+++ b/src/compiler/assets/modules/comparator.test.ts
@@ -4,20 +4,85 @@ import { getComparatorModuleDefinition } from "./comparator";
 import { fromNumber2IntBase, toBoolean } from "../../js-bindings";
 
 describe(getComparatorModuleDefinition, () => {
+  describe("without float nor list", () => {
+    it("should calc lt correctly", async () => {
+      expect(await compInt(1, "lt", 1, true)).toBe(false);
+      expect(await compInt(1, "lt", 0, true)).toBe(false);
+      expect(await compInt(1, "lt", 2, true)).toBe(true);
+    });
+
+    it("should calc le correctly", async () => {
+      expect(await compInt(1, "le", 1, true)).toBe(true);
+      expect(await compInt(1, "le", 0, true)).toBe(false);
+      expect(await compInt(1, "le", 2, true)).toBe(true);
+    });
+
+    it("should calc gt correctly", async () => {
+      expect(await compInt(1, "gt", 1, true)).toBe(false);
+      expect(await compInt(1, "gt", 0, true)).toBe(true);
+      expect(await compInt(1, "gt", 2, true)).toBe(false);
+    });
+
+    it("should calc ge correctly", async () => {
+      expect(await compInt(1, "ge", 1, true)).toBe(true);
+      expect(await compInt(1, "ge", 0, true)).toBe(true);
+      expect(await compInt(1, "ge", 2, true)).toBe(false);
+    });
+  });
+
   describe("with integer operand", () => {
     it("should calc lt correctly", async () => {
       expect(await compInt(1, "lt", 1)).toBe(false);
       expect(await compInt(1, "lt", 0)).toBe(false);
       expect(await compInt(1, "lt", 2)).toBe(true);
     });
+
+    it("should calc le correctly", async () => {
+      expect(await compInt(1, "le", 1)).toBe(true);
+      expect(await compInt(1, "le", 0)).toBe(false);
+      expect(await compInt(1, "le", 2)).toBe(true);
+    });
+
+    it("should calc gt correctly", async () => {
+      expect(await compInt(1, "gt", 1)).toBe(false);
+      expect(await compInt(1, "gt", 0)).toBe(true);
+      expect(await compInt(1, "gt", 2)).toBe(false);
+    });
+
+    it("should calc ge correctly", async () => {
+      expect(await compInt(1, "ge", 1)).toBe(true);
+      expect(await compInt(1, "ge", 0)).toBe(true);
+      expect(await compInt(1, "ge", 2)).toBe(false);
+    });
   });
 
-  describe("boolean comparison", () => {
+  describe("with boolean comparison", () => {
     it("should calc lt correctly", async () => {
       expect(await compBool(false, "lt", false)).toBe(false);
       expect(await compBool(true, "lt", true)).toBe(false);
       expect(await compBool(true, "lt", false)).toBe(false);
       expect(await compBool(false, "lt", true)).toBe(true);
+    });
+
+    it("should calc le correctly", async () => {
+      expect(await compBool(false, "le", false)).toBe(true);
+      expect(await compBool(true, "le", true)).toBe(true);
+      expect(await compBool(true, "le", false)).toBe(false);
+      expect(await compBool(false, "le", true)).toBe(true);
+    });
+
+    it("should calc gt correctly", async () => {
+      expect(await compBool(false, "gt", false)).toBe(false);
+      expect(await compBool(true, "gt", true)).toBe(false);
+      expect(await compBool(true, "gt", false)).toBe(true);
+      expect(await compBool(false, "gt", true)).toBe(false);
+    });
+
+    it("should calc ge correctly", async () => {
+      expect(await compBool(false, "ge", false)).toBe(true);
+      expect(await compBool(true, "ge", true)).toBe(true);
+      expect(await compBool(true, "ge", false)).toBe(true);
+      expect(await compBool(false, "ge", true)).toBe(false);
     });
   });
 
@@ -27,110 +92,530 @@ describe(getComparatorModuleDefinition, () => {
       expect(await compFloat(1.0, "lt", 0.0)).toBe(false);
       expect(await compFloat(0.0, "lt", 1.0)).toBe(true);
     });
+
+    it("should calc le correctly", async () => {
+      expect(await compFloat(0.0, "le", 0.0)).toBe(true);
+      expect(await compFloat(1.0, "le", 0.0)).toBe(false);
+      expect(await compFloat(0.0, "le", 1.0)).toBe(true);
+    });
+
+    it("should calc gt correctly", async () => {
+      expect(await compFloat(0.0, "gt", 0.0)).toBe(false);
+      expect(await compFloat(1.0, "gt", 0.0)).toBe(true);
+      expect(await compFloat(0.0, "gt", 1.0)).toBe(false);
+    });
+
+    it("should calc ge correctly", async () => {
+      expect(await compFloat(0.0, "ge", 0.0)).toBe(true);
+      expect(await compFloat(1.0, "ge", 0.0)).toBe(true);
+      expect(await compFloat(0.0, "ge", 1.0)).toBe(false);
+    });
   });
 
   describe("with list comparison", () => {
-    test("1::[] < [] = false", async () => {
-      expect(
-        await compWithModuleCode(
-          `
-            (module
-              (func $test (result i32)
-                ;; L1
-                call $__list_new__
-                i32.const 1
-                call $__list_push__
+    describe("lt", () => {
+      test("false::[] < [] = false", async () => {
+        expect(
+          await compWithModuleCode(
+            `
+              (module
+                (func $test (result i32)
+                  ;; L1
+                  call $__list_new__
+                  i32.const 0
+                  call $__list_push__
 
-                ;; L2
-                call $__list_new__
+                  ;; L2
+                  call $__list_new__
 
-                call $__comparator_poly_lt__
+                  call $__comparator_poly_lt__
+                )
+                (export "test" (func $test))
               )
-              (export "test" (func $test))
-            )
-          `,
-        ),
-      ).toBe(false);
+            `,
+          ),
+        ).toBe(false);
+      });
+
+      test("false::[] < false::[] = false", async () => {
+        expect(
+          await compWithModuleCode(
+            `
+              (module
+                (func $test (result i32)
+                  ;; L1
+                  call $__list_new__
+                  i32.const 0
+                  call $__list_push__
+
+                  ;; L2
+                  call $__list_new__
+                  i32.const 0
+                  call $__list_push__
+
+                  call $__comparator_poly_lt__
+                )
+                (export "test" (func $test))
+              )
+            `,
+          ),
+        ).toBe(false);
+      });
+
+      test("true::[] < false::[] = false", async () => {
+        expect(
+          await compWithModuleCode(
+            `
+              (module
+                (func $test (result i32)
+                  ;; L1
+                  call $__list_new__
+                  i32.const 1
+                  call $__list_push__
+
+                  ;; L2
+                  call $__list_new__
+                  i32.const 0
+                  call $__list_push__
+
+                  call $__comparator_poly_lt__
+                )
+                (export "test" (func $test))
+              )
+            `,
+          ),
+        ).toBe(false);
+      });
+
+      test("[] < false::[] = true", async () => {
+        expect(
+          await compWithModuleCode(
+            `
+              (module
+                (func $test (result i32)
+                  ;; L1
+                  call $__list_new__
+
+                  ;; L2
+                  call $__list_new__
+                  i32.const 0
+                  call $__list_push__
+
+                  call $__comparator_poly_lt__
+                )
+                (export "test" (func $test))
+              )
+            `,
+          ),
+        ).toBe(true);
+      });
+
+      test("false::true::[] < true::[] = true", async () => {
+        expect(
+          await compWithModuleCode(
+            `
+              (module
+                (func $test (result i32)
+                  ;; L1
+                  call $__list_new__
+                  i32.const 1
+                  call $__list_push__
+                  i32.const 0
+                  call $__list_push__
+
+                  ;; L2
+                  call $__list_new__
+                  i32.const 1
+                  call $__list_push__
+
+                  call $__comparator_poly_lt__
+                )
+                (export "test" (func $test))
+              )
+            `,
+          ),
+        ).toBe(true);
+      });
     });
 
-    test("1::[] < 1::[] = false", async () => {
-      expect(
-        await compWithModuleCode(
-          `
-            (module
-              (func $test (result i32)
-                ;; L1
-                call $__list_new__
-                i32.const 1
-                call $__list_push__
+    describe("le", () => {
+      test("false::[] <= [] = false", async () => {
+        expect(
+          await compWithModuleCode(
+            `
+              (module
+                (func $test (result i32)
+                  ;; L1
+                  call $__list_new__
+                  i32.const 0
+                  call $__list_push__
 
-                ;; L2
-                call $__list_new__
-                i32.const 1
-                call $__list_push__
+                  ;; L2
+                  call $__list_new__
 
-                call $__comparator_poly_lt__
+                  call $__comparator_poly_le__
+                )
+                (export "test" (func $test))
               )
-              (export "test" (func $test))
-            )
-          `,
-        ),
-      ).toBe(false);
+            `,
+          ),
+        ).toBe(false);
+      });
+
+      test("false::[] <= false::[] = true", async () => {
+        expect(
+          await compWithModuleCode(
+            `
+              (module
+                (func $test (result i32)
+                  ;; L1
+                  call $__list_new__
+                  i32.const 0
+                  call $__list_push__
+
+                  ;; L2
+                  call $__list_new__
+                  i32.const 0
+                  call $__list_push__
+
+                  call $__comparator_poly_le__
+                )
+                (export "test" (func $test))
+              )
+            `,
+          ),
+        ).toBe(true);
+      });
+
+      test("true::[] <= false::[] = false", async () => {
+        expect(
+          await compWithModuleCode(
+            `
+              (module
+                (func $test (result i32)
+                  ;; L1
+                  call $__list_new__
+                  i32.const 1
+                  call $__list_push__
+
+                  ;; L2
+                  call $__list_new__
+                  i32.const 0
+                  call $__list_push__
+
+                  call $__comparator_poly_le__
+                )
+                (export "test" (func $test))
+              )
+            `,
+          ),
+        ).toBe(false);
+      });
+
+      test("[] <= false::[] = true", async () => {
+        expect(
+          await compWithModuleCode(
+            `
+              (module
+                (func $test (result i32)
+                  ;; L1
+                  call $__list_new__
+
+                  ;; L2
+                  call $__list_new__
+                  i32.const 0
+                  call $__list_push__
+
+                  call $__comparator_poly_le__
+                )
+                (export "test" (func $test))
+              )
+            `,
+          ),
+        ).toBe(true);
+      });
+
+      test("false::true::[] <= true::[] = true", async () => {
+        expect(
+          await compWithModuleCode(
+            `
+              (module
+                (func $test (result i32)
+                  ;; L1
+                  call $__list_new__
+                  i32.const 1
+                  call $__list_push__
+                  i32.const 0
+                  call $__list_push__
+
+                  ;; L2
+                  call $__list_new__
+                  i32.const 1
+                  call $__list_push__
+
+                  call $__comparator_poly_le__
+                )
+                (export "test" (func $test))
+              )
+            `,
+          ),
+        ).toBe(true);
+      });
     });
 
-    test("[] < 1::[] = true", async () => {
-      expect(
-        await compWithModuleCode(
-          `
-            (module
-              (func $test (result i32)
-                ;; L1
-                call $__list_new__
+    describe("gt", () => {
+      test("[] > false::[] = false", async () => {
+        expect(
+          await compWithModuleCode(
+            `
+              (module
+                (func $test (result i32)
+                  ;; L1
+                  call $__list_new__
 
-                ;; L2
-                call $__list_new__
-                i32.const 1
-                call $__list_push__
+                  ;; L2
+                  call $__list_new__
+                  i32.const 0
+                  call $__list_push__
 
-                call $__comparator_poly_lt__
+                  call $__comparator_poly_gt__
+                )
+                (export "test" (func $test))
               )
-              (export "test" (func $test))
-            )
-          `,
-        ),
-      ).toBe(true);
+            `,
+          ),
+        ).toBe(false);
+      });
+
+      test("false::[] > false::[] = false", async () => {
+        expect(
+          await compWithModuleCode(
+            `
+              (module
+                (func $test (result i32)
+                  ;; L1
+                  call $__list_new__
+                  i32.const 0
+                  call $__list_push__
+
+                  ;; L2
+                  call $__list_new__
+                  i32.const 0
+                  call $__list_push__
+
+                  call $__comparator_poly_gt__
+                )
+                (export "test" (func $test))
+              )
+            `,
+          ),
+        ).toBe(false);
+      });
+
+      test("false::[] > true::[] = false", async () => {
+        expect(
+          await compWithModuleCode(
+            `
+              (module
+                (func $test (result i32)
+                  ;; L1
+                  call $__list_new__
+                  i32.const 0
+                  call $__list_push__
+
+                  ;; L2
+                  call $__list_new__
+                  i32.const 1
+                  call $__list_push__
+
+                  call $__comparator_poly_gt__
+                )
+                (export "test" (func $test))
+              )
+            `,
+          ),
+        ).toBe(false);
+      });
+
+      test("false::[] > [] = true", async () => {
+        expect(
+          await compWithModuleCode(
+            `
+              (module
+                (func $test (result i32)
+                  ;; L1
+                  call $__list_new__
+                  i32.const 0
+                  call $__list_push__
+
+                  ;; L2
+                  call $__list_new__
+
+                  call $__comparator_poly_gt__
+                )
+                (export "test" (func $test))
+              )
+            `,
+          ),
+        ).toBe(true);
+      });
+
+      test("true::[] > false::true::[] = true", async () => {
+        expect(
+          await compWithModuleCode(
+            `
+              (module
+                (func $test (result i32)
+                  ;; L1
+                  call $__list_new__
+                  i32.const 1
+                  call $__list_push__
+
+                  ;; L2
+                  call $__list_new__
+                  i32.const 1
+                  call $__list_push__
+                  i32.const 0
+                  call $__list_push__
+
+                  call $__comparator_poly_gt__
+                )
+                (export "test" (func $test))
+              )
+            `,
+          ),
+        ).toBe(true);
+      });
     });
 
-    test("1::2::[] < 2::[] = true", async () => {
-      expect(
-        await compWithModuleCode(
-          `
-            (module
-              (func $test (result i32)
-                ;; L1
-                call $__list_new__
-                i32.const 2
-                call $__list_push__
-                i32.const 1
-                call $__list_push__
+    describe("ge", () => {
+      test("[] >= false::[] = false", async () => {
+        expect(
+          await compWithModuleCode(
+            `
+              (module
+                (func $test (result i32)
+                  ;; L1
+                  call $__list_new__
 
-                ;; L2
-                call $__list_new__
-                i32.const 2
-                call $__list_push__
+                  ;; L2
+                  call $__list_new__
+                  i32.const 0
+                  call $__list_push__
 
-                call $__comparator_poly_lt__
+                  call $__comparator_poly_ge__
+                )
+                (export "test" (func $test))
               )
-              (export "test" (func $test))
-            )
-          `,
-        ),
-      ).toBe(true);
+            `,
+          ),
+        ).toBe(false);
+      });
+
+      test("false::[] >= false::[] = true", async () => {
+        expect(
+          await compWithModuleCode(
+            `
+              (module
+                (func $test (result i32)
+                  ;; L1
+                  call $__list_new__
+                  i32.const 0
+                  call $__list_push__
+
+                  ;; L2
+                  call $__list_new__
+                  i32.const 0
+                  call $__list_push__
+
+                  call $__comparator_poly_ge__
+                )
+                (export "test" (func $test))
+              )
+            `,
+          ),
+        ).toBe(true);
+      });
+
+      test("false::[] >= true::[] = false", async () => {
+        expect(
+          await compWithModuleCode(
+            `
+              (module
+                (func $test (result i32)
+                  ;; L1
+                  call $__list_new__
+                  i32.const 0
+                  call $__list_push__
+
+                  ;; L2
+                  call $__list_new__
+                  i32.const 1
+                  call $__list_push__
+
+                  call $__comparator_poly_ge__
+                )
+                (export "test" (func $test))
+              )
+            `,
+          ),
+        ).toBe(false);
+      });
+
+      test("false::[] >= [] = true", async () => {
+        expect(
+          await compWithModuleCode(
+            `
+              (module
+                (func $test (result i32)
+                  ;; L1
+                  call $__list_new__
+                  i32.const 0
+                  call $__list_push__
+
+                  ;; L2
+                  call $__list_new__
+
+                  call $__comparator_poly_ge__
+                )
+                (export "test" (func $test))
+              )
+            `,
+          ),
+        ).toBe(true);
+      });
+
+      test("true::[] >= false::true::[] = true", async () => {
+        expect(
+          await compWithModuleCode(
+            `
+              (module
+                (func $test (result i32)
+                  ;; L1
+                  call $__list_new__
+                  i32.const 1
+                  call $__list_push__
+
+                  ;; L2
+                  call $__list_new__
+                  i32.const 1
+                  call $__list_push__
+                  i32.const 0
+                  call $__list_push__
+
+                  call $__comparator_poly_ge__
+                )
+                (export "test" (func $test))
+              )
+            `,
+          ),
+        ).toBe(true);
+      });
     });
   });
 });
 
-async function compInt(left: number, op: "lt" | "le" | "gt" | "ge", right: number) {
+async function compInt(left: number, op: "lt" | "le" | "gt" | "ge", right: number, simple = false) {
   const buf = new ModuleBuilder({
     name: "test",
     code: `
@@ -143,7 +628,7 @@ async function compInt(left: number, op: "lt" | "le" | "gt" | "ge", right: numbe
           (export "test" (func $test))
         )
       `,
-    dependencies: [getComparatorModuleDefinition({ withFloat: true, withList: false })],
+    dependencies: [getComparatorModuleDefinition({ includeOperators: [op], withFloat: !simple, withList: false })],
   })
     .build()
     .mapValue(generateBinary)
@@ -168,7 +653,7 @@ async function compBool(left: boolean, op: "lt" | "le" | "gt" | "ge", right: boo
           (export "test" (func $test))
         )
       `,
-    dependencies: [getComparatorModuleDefinition({ withFloat: true, withList: false })],
+    dependencies: [getComparatorModuleDefinition({ includeOperators: [op], withFloat: true, withList: false })],
   })
     .build()
     .mapValue(generateBinary)
@@ -192,7 +677,7 @@ async function compFloat(left: number, op: "lt" | "le" | "gt" | "ge", right: num
           (export "test" (func $test))
         )
       `,
-    dependencies: [getComparatorModuleDefinition({ withFloat: true, withList: false })],
+    dependencies: [getComparatorModuleDefinition({ includeOperators: [op], withFloat: true, withList: false })],
   })
     .build()
     .mapValue(generateBinary)
@@ -205,7 +690,9 @@ async function compWithModuleCode(code: string) {
   const buf = new ModuleBuilder({
     name: "test",
     code,
-    dependencies: [getComparatorModuleDefinition({ withFloat: true, withList: false })],
+    dependencies: [
+      getComparatorModuleDefinition({ includeOperators: ["lt", "le", "gt", "ge"], withFloat: true, withList: true }),
+    ],
   })
     .build()
     .mapValue(generateBinary)

--- a/src/compiler/assets/modules/comparator.ts
+++ b/src/compiler/assets/modules/comparator.ts
@@ -1,0 +1,109 @@
+import { ModuleDefinition } from "../../module-builder";
+import { getListModuleDefinition } from "./list";
+import { getFloatModuleDefinition } from "./float";
+
+export type ComparisonOperators = "lt" | "le" | "gt" | "ge";
+
+export function getComparatorModuleDefinition({}: {
+  readonly includeOperators: readonly ComparisonOperators[];
+  readonly withFloat: boolean;
+  readonly withList: boolean;
+}): ModuleDefinition {
+  return {
+    name: "lib/comparator",
+    code: `
+      (module
+        (func $__comparator_list_lt__ (param $l1 i32) (param $l2 i32) (result i32)
+          local.get $l1
+          if (result i32)
+            local.get $l2
+            if (result i32)
+              local.get $l1
+              call $__list_head__
+              local.get $l2
+              call $__list_head__
+              call $__comparator_poly_lt__
+              if (result i32)
+                i32.const 1
+              else
+                local.get $l1
+                call $__list_tail__
+                local.get $l2
+                call $__list_tail__
+                call $__comparator_list_lt__
+              end
+            else
+              ;; if List.length l1 > 1 and List.length l2 = 0 then false
+              i32.const 0
+            end
+          else
+            local.get $l1
+            local.get $l2
+            i32.lt_s
+          end
+        )
+
+        (func $__comparator_poly_lt__ (param $left i32) (param $right i32) (result i32) (local $tag i32)
+          local.get $left
+          i32.const 1
+          i32.and
+          if (result i32)
+            ;; $left is true or signed-integer
+            local.get $left
+            local.get $right
+            i32.lt_s
+          else
+            ;; $left is false or empty list or address
+            local.get $left
+            if (result i32)
+              local.get $left
+              i32.const 14
+              i32.and
+              local.tee $tag
+              i32.const 2
+              i32.eq
+              if (result i32)
+                ;; $left and $right is floating-point number
+                local.get $left
+                call $__float_get__
+                local.get $right
+                call $__float_get__
+                f64.lt
+              else
+                local.get $tag
+                i32.const 4
+                i32.eq
+                if (result i32)
+                  ;; $left is non-empty list
+                  local.get $left
+                  local.get $right
+                  call $__comparator_list_lt__
+                else
+                  unreachable
+                end
+              end
+            else
+              ;; $left is false or emptyList
+              local.get $left
+              local.get $right
+              i32.lt_s
+            end
+          end
+        )
+
+        (func $__comparator_poly_le__ (param $a i32) (param $b i32) (result i32)
+          i32.const 0
+        )
+
+        (func $__comparator_poly_gt__ (param $a i32) (param $b i32) (result i32)
+          i32.const 0
+        )
+
+        (func $__comparator_poly_ge__ (param $a i32) (param $b i32) (result i32)
+          i32.const 0
+        )
+      )
+    `,
+    dependencies: [getFloatModuleDefinition(), getListModuleDefinition()],
+  };
+}

--- a/src/compiler/assets/modules/comparator.ts
+++ b/src/compiler/assets/modules/comparator.ts
@@ -2,108 +2,239 @@ import { ModuleDefinition } from "../../module-builder";
 import { getListModuleDefinition } from "./list";
 import { getFloatModuleDefinition } from "./float";
 
-export type ComparisonOperators = "lt" | "le" | "gt" | "ge";
+export type ComparisonOperators = "eq" | "lt" | "le" | "gt" | "ge";
 
-export function getComparatorModuleDefinition({}: {
+const polymorphicComparatorTemplate = (
+  op: ComparisonOperators,
+  { withFloat, withList }: { readonly withList: boolean; readonly withFloat: boolean },
+) => {
+  if (!withFloat && !withList) {
+    return `
+      (func $__comparator_poly_${op}__ (param $left i32) (param $right i32) (result i32)
+        local.get $left
+        local.get $right
+        i32.${op}_s
+      )
+    `;
+  }
+  const ifFloatBlock = withFloat
+    ? `
+        local.get $tag
+        i32.const 2
+        i32.eq
+        if (result i32)
+          ;; $left and $right is floating-point number
+          local.get $left
+          call $__float_get__
+          local.get $right
+          call $__float_get__
+          f64.${op}
+        else
+    `
+    : "";
+  const endIfFloat = withFloat ? "end" : "";
+  const ifListBlock = withList
+    ? `
+        local.get $tag
+        i32.const 4
+        i32.eq
+        if (result i32)
+          ;; $left is non-empty list
+          local.get $left
+          local.get $right
+          call $__comparator_list_${op}__
+        else
+       `
+    : "";
+  const endIfList = withList ? "end" : "";
+  return `
+    (func $__comparator_poly_${op}__ (param $left i32) (param $right i32) (result i32) (local $tag i32)
+      local.get $left
+      i32.const 1
+      i32.and
+      if (result i32)
+        ;; $left is true or signed-integer
+        local.get $left
+        local.get $right
+        i32.${op}_s
+      else
+        ;; $left is false or empty list or address
+        local.get $left
+        if (result i32)
+          local.get $left
+          i32.const 14
+          i32.and
+          local.set $tag
+          ${ifFloatBlock}
+            ${ifListBlock}
+              unreachable
+            ${endIfList}
+          ${endIfFloat}
+        else
+          ;; $left is false or emptyList
+          local.get $left
+          local.get $right
+          i32.${op}_s
+        end
+      end
+    )
+  `;
+};
+
+const listComparatorTemplate = (op: ComparisonOperators) => `
+  (func $__comparator_list_${op}__ (param $l1 i32) (param $l2 i32) (result i32) (local $h1 i32) (local $h2 i32)
+    local.get $l1
+    if (result i32)
+      local.get $l2
+      if (result i32)
+        local.get $l1
+        call $__list_head__
+        local.tee $h1
+        local.get $l2
+        call $__list_head__
+        local.tee $h2
+        call $__comparator_poly_${op}__
+        if (result i32)
+          i32.const 1
+        else
+          local.get $h1
+          local.get $h2
+          call $__comparator_poly_eq__
+          if (result i32)
+            local.get $l1
+            call $__list_tail__
+            local.get $l2
+            call $__list_tail__
+            call $__comparator_list_${op}__
+          else
+            i32.const 0
+          end
+        end
+      else
+        ${op === "gt" || op === "ge" ? "i32.const 1" : "i32.const 0"}
+      end
+    else
+      local.get $l1
+      local.get $l2
+      ${op === "eq" ? "i32.eq" : "i32." + op + "_s"}
+    end
+  )
+`;
+
+const polymorphicEqualityTemplate = ({
+  withFloat,
+  withList,
+}: {
+  readonly withList: boolean;
+  readonly withFloat: boolean;
+}) => {
+  if (!withFloat && !withList) {
+    return `
+      (func $__comparator_poly_eq__ (param $left i32) (param $right i32) (result i32)
+        local.get $left
+        local.get $right
+        i32.eq
+      )
+    `;
+  }
+  const ifFloatBlock = withFloat
+    ? `
+        local.get $tag
+        i32.const 2
+        i32.eq
+        if (result i32)
+          ;; $left and $right is floating-point number
+          local.get $left
+          call $__float_get__
+          local.get $right
+          call $__float_get__
+          f64.eq
+        else
+    `
+    : "";
+  const endIfFloat = withFloat ? "end" : "";
+  const ifListBlock = withList
+    ? `
+        local.get $tag
+        i32.const 4
+        i32.eq
+        if (result i32)
+          ;; $left is non-empty list
+          local.get $left
+          local.get $right
+          call $__comparator_list_eq__
+        else
+       `
+    : "";
+  const endIfList = withList ? "end" : "";
+  return `
+    (func $__comparator_poly_eq__ (param $left i32) (param $right i32) (result i32) (local $tag i32)
+      local.get $left
+      i32.const 1
+      i32.and
+      if (result i32)
+        local.get $left
+        local.get $right
+        i32.eq
+      else
+        local.get $left
+        if (result i32)
+          local.get $left
+          i32.const 14
+          i32.and
+          local.set $tag
+          ${ifFloatBlock}
+            ${ifListBlock}
+              unreachable
+            ${endIfList}
+          ${endIfFloat}
+        else
+          local.get $left
+          local.get $right
+          i32.eq
+        end
+      end
+    )
+  `;
+};
+
+export function getComparatorModuleDefinition({
+  includeOperators,
+  withFloat,
+  withList,
+}: {
   readonly includeOperators: readonly ComparisonOperators[];
   readonly withFloat: boolean;
   readonly withList: boolean;
 }): ModuleDefinition {
+  const hasLt = includeOperators.indexOf("lt") !== -1;
+  const hasLe = includeOperators.indexOf("le") !== -1;
+  const hasGt = includeOperators.indexOf("gt") !== -1;
+  const hasGe = includeOperators.indexOf("ge") !== -1;
   return {
     name: "lib/comparator",
     code: `
       (module
-        (func $__comparator_list_lt__ (param $l1 i32) (param $l2 i32) (result i32)
-          local.get $l1
-          if (result i32)
-            local.get $l2
-            if (result i32)
-              local.get $l1
-              call $__list_head__
-              local.get $l2
-              call $__list_head__
-              call $__comparator_poly_lt__
-              if (result i32)
-                i32.const 1
-              else
-                local.get $l1
-                call $__list_tail__
-                local.get $l2
-                call $__list_tail__
-                call $__comparator_list_lt__
-              end
-            else
-              ;; if List.length l1 > 1 and List.length l2 = 0 then false
-              i32.const 0
-            end
-          else
-            local.get $l1
-            local.get $l2
-            i32.lt_s
-          end
-        )
 
-        (func $__comparator_poly_lt__ (param $left i32) (param $right i32) (result i32) (local $tag i32)
-          local.get $left
-          i32.const 1
-          i32.and
-          if (result i32)
-            ;; $left is true or signed-integer
-            local.get $left
-            local.get $right
-            i32.lt_s
-          else
-            ;; $left is false or empty list or address
-            local.get $left
-            if (result i32)
-              local.get $left
-              i32.const 14
-              i32.and
-              local.tee $tag
-              i32.const 2
-              i32.eq
-              if (result i32)
-                ;; $left and $right is floating-point number
-                local.get $left
-                call $__float_get__
-                local.get $right
-                call $__float_get__
-                f64.lt
-              else
-                local.get $tag
-                i32.const 4
-                i32.eq
-                if (result i32)
-                  ;; $left is non-empty list
-                  local.get $left
-                  local.get $right
-                  call $__comparator_list_lt__
-                else
-                  unreachable
-                end
-              end
-            else
-              ;; $left is false or emptyList
-              local.get $left
-              local.get $right
-              i32.lt_s
-            end
-          end
-        )
+        ${hasLt ? polymorphicComparatorTemplate("lt", { withList, withFloat }) : ""}
+        ${hasLt && withList ? listComparatorTemplate("lt") : ""}
 
-        (func $__comparator_poly_le__ (param $a i32) (param $b i32) (result i32)
-          i32.const 0
-        )
+        ${hasLe ? polymorphicComparatorTemplate("le", { withList, withFloat }) : ""}
+        ${hasLe && withList ? listComparatorTemplate("le") : ""}
 
-        (func $__comparator_poly_gt__ (param $a i32) (param $b i32) (result i32)
-          i32.const 0
-        )
+        ${hasGt ? polymorphicComparatorTemplate("gt", { withList, withFloat }) : ""}
+        ${hasGt && withList ? listComparatorTemplate("gt") : ""}
 
-        (func $__comparator_poly_ge__ (param $a i32) (param $b i32) (result i32)
-          i32.const 0
-        )
+        ${hasGe ? polymorphicComparatorTemplate("ge", { withList, withFloat }) : ""}
+        ${hasGe && withList ? listComparatorTemplate("ge") : ""}
+
+        ${withList ? listComparatorTemplate("eq") : ""}
+        ${withList ? polymorphicEqualityTemplate({ withList, withFloat }) : ""}
       )
     `,
-    dependencies: [getFloatModuleDefinition(), getListModuleDefinition()],
+    dependencies: [
+      ...(withFloat ? [getFloatModuleDefinition()] : []),
+      ...(withList ? [getListModuleDefinition()] : []),
+    ],
   };
 }

--- a/src/compiler/assets/modules/comparator.ts
+++ b/src/compiler/assets/modules/comparator.ts
@@ -1,3 +1,4 @@
+import { factory } from "../../../wasm";
 import { ModuleDefinition } from "../../module-builder";
 import { getListModuleDefinition } from "./list";
 import { getFloatModuleDefinition } from "./float";
@@ -237,4 +238,8 @@ export function getComparatorModuleDefinition({
       ...(withList ? [getListModuleDefinition()] : []),
     ],
   };
+}
+
+export function compareInstr(op: ComparisonOperators) {
+  return [factory.controlInstr("call", [factory.identifier(`__comparator_poly_${op}__`)])];
 }

--- a/src/compiler/assets/modules/env.ts
+++ b/src/compiler/assets/modules/env.ts
@@ -50,7 +50,7 @@ export function paramTypeForEnv() {
 
 export function initEnvInstr() {
   return [
-    factory.numericInstr("i32.const", [factory.int32(-1)]),
+    factory.int32NumericInstr("i32.const", [factory.int32(-1)]),
     factory.variableInstr("local.set", [factory.identifier("current_env_addr")]),
   ];
 }
@@ -82,7 +82,7 @@ export function popEnvInstr() {
 export function getEnvValueInstr(index: number) {
   return [
     factory.variableInstr("local.get", [factory.identifier("current_env_addr")]),
-    factory.numericInstr("i32.const", [factory.int32(index)]),
+    factory.int32NumericInstr("i32.const", [factory.int32(index)]),
     factory.controlInstr("call", [factory.identifier("__env_get__")]),
   ];
 }

--- a/src/compiler/assets/modules/float.test.ts
+++ b/src/compiler/assets/modules/float.test.ts
@@ -1,0 +1,27 @@
+import { generateBinaryWithDefaultOptions as generateBinary } from "../../../wasm";
+import { ModuleBuilder } from "../../module-builder";
+import { getFloatModuleDefinition } from "./float";
+
+describe(getFloatModuleDefinition, () => {
+  it("should store floating point value", async () => {
+    const buf = new ModuleBuilder({
+      name: "test",
+      code: `
+        (module
+          (func $test (result f64)
+            f64.const 3.14
+            call $__float_new__ 
+            call $__float_get__
+          )
+          (export "test" (func $test))
+        )
+      `,
+      dependencies: [getFloatModuleDefinition()],
+    })
+      .build()
+      .mapValue(generateBinary)
+      .unwrap();
+    const { instance } = await WebAssembly.instantiate(buf, {});
+    expect((instance.exports["test"] as Function)()).toBe(3.14);
+  });
+});

--- a/src/compiler/assets/modules/float.ts
+++ b/src/compiler/assets/modules/float.ts
@@ -13,9 +13,15 @@ const definition: ModuleDefinition = {
         local.get $value
         f64.store offset=0
         local.get $addr
+        i32.const 3
+        i32.shl 
+        i32.const 2
+        i32.or
       )
       (func $__float_get__ (param $addr i32) (result f64)
         local.get $addr
+        i32.const 3
+        i32.shr_u
         f64.load offset=0
       )
       (export "__float_get__" (func $__float_get__))
@@ -33,6 +39,10 @@ export function newFloatInstr(value: number) {
     factory.float64NumericInstr("f64.const", [factory.float64(value)]),
     factory.controlInstr("call", [factory.identifier("__float_new__")]),
   ];
+}
+
+export function storeFloatValueInstr() {
+  return [factory.controlInstr("call", [factory.identifier("__float_new__")])];
 }
 
 export function getFloatValueInstr() {

--- a/src/compiler/assets/modules/float.ts
+++ b/src/compiler/assets/modules/float.ts
@@ -1,0 +1,40 @@
+import { factory } from "../../../wasm";
+import { ModuleDefinition } from "../../module-builder";
+import { getAllocatorModuleDefinition } from "./alloc";
+
+const definition: ModuleDefinition = {
+  name: "lib/float",
+  code: `
+    (module
+      (func $__float_new__ (param $value f64) (result i32) (local $addr i32)
+        i32.const 8
+        call $__malloc__
+        local.tee $addr
+        local.get $value
+        f64.store offset=0
+        local.get $addr
+      )
+      (func $__float_get__ (param $addr i32) (result f64)
+        local.get $addr
+        f64.load offset=0
+      )
+      (export "__float_get__" (func $__float_get__))
+    )
+  `,
+  dependencies: [getAllocatorModuleDefinition()],
+};
+
+export function getFloatModuleDefinition() {
+  return definition;
+}
+
+export function newFloatInstr(value: number) {
+  return [
+    factory.float64NumericInstr("f64.const", [factory.float64(value)]),
+    factory.controlInstr("call", [factory.identifier("__float_new__")]),
+  ];
+}
+
+export function getFloatValueInstr() {
+  return [factory.controlInstr("call", [factory.identifier("__float_get__")])];
+}

--- a/src/compiler/assets/modules/float.ts
+++ b/src/compiler/assets/modules/float.ts
@@ -13,14 +13,19 @@ const definition: ModuleDefinition = {
         local.get $value
         f64.store offset=0
         local.get $addr
-        i32.const 3
+
+        ;; Note:
+        ;; We should add the following tag to LSB 4-bits of the floating-point number address.
+        ;; [0010] = 0x2
+
+        i32.const 4
         i32.shl 
         i32.const 2
         i32.or
       )
       (func $__float_get__ (param $addr i32) (result f64)
         local.get $addr
-        i32.const 3
+        i32.const 4
         i32.shr_u
         f64.load offset=0
       )

--- a/src/compiler/assets/modules/list.ts
+++ b/src/compiler/assets/modules/list.ts
@@ -15,6 +15,14 @@ const definition: ModuleDefinition = {
         local.get $list_addr
         local.get $value
         call $__tuple_new__
+
+        ;; Note:
+        ;; We should add the following tag to LSB 4-bits of the list address.
+        ;; [0100] = 0x4
+        i32.const 4
+        i32.shl
+        i32.const 4
+        i32.or
       )
 
       (func $__list_is_empty__ (param $list_addr i32) (result i32)
@@ -25,11 +33,15 @@ const definition: ModuleDefinition = {
 
       (func $__list_head__ (param $list_addr i32) (result i32)
         local.get $list_addr
+        i32.const 4
+        i32.shr_u
         call $__tuple_get_v1__
       )
 
       (func $__list_tail__ (param $list_addr i32) (result i32)
         local.get $list_addr
+        i32.const 4
+        i32.shr_u
         call $__tuple_get_v0__
       )
 

--- a/src/compiler/compile-node/binary-expression.ts
+++ b/src/compiler/compile-node/binary-expression.ts
@@ -14,49 +14,49 @@ function getOperationInstr(
       return ok([
         ...left,
         ...right,
-        factory.numericInstr("i32.add", []),
-        factory.numericInstr("i32.const", [factory.int32(1)]),
-        factory.numericInstr("i32.sub", []),
+        factory.int32NumericInstr("i32.add", []),
+        factory.int32NumericInstr("i32.const", [factory.int32(1)]),
+        factory.int32NumericInstr("i32.sub", []),
       ]);
     case "Sub":
       // 2(a - b) + 1 = (2a + 1) - (2b + 1) + 1 = A - B + 1
       return ok([
         ...left,
         ...right,
-        factory.numericInstr("i32.sub", []),
-        factory.numericInstr("i32.const", [factory.int32(1)]),
-        factory.numericInstr("i32.add", []),
+        factory.int32NumericInstr("i32.sub", []),
+        factory.int32NumericInstr("i32.const", [factory.int32(1)]),
+        factory.int32NumericInstr("i32.add", []),
       ]);
     case "Multiply": {
       // 2ab + 1 = (2a + 1 - 1) * b  + 1 = (A - 1) * (B >> 1) + 1
       return ok([
         ...left,
-        factory.numericInstr("i32.const", [factory.int32(1)]),
-        factory.numericInstr("i32.sub", []),
+        factory.int32NumericInstr("i32.const", [factory.int32(1)]),
+        factory.int32NumericInstr("i32.sub", []),
         ...right,
-        factory.numericInstr("i32.const", [factory.int32(1)]),
-        factory.numericInstr("i32.shr_s", []),
-        factory.numericInstr("i32.mul", []),
-        factory.numericInstr("i32.const", [factory.int32(1)]),
-        factory.numericInstr("i32.add", []),
+        factory.int32NumericInstr("i32.const", [factory.int32(1)]),
+        factory.int32NumericInstr("i32.shr_s", []),
+        factory.int32NumericInstr("i32.mul", []),
+        factory.int32NumericInstr("i32.const", [factory.int32(1)]),
+        factory.int32NumericInstr("i32.add", []),
       ]);
     }
     case "Or":
-      return ok([...left, ...right, factory.numericInstr("i32.or", [])]);
+      return ok([...left, ...right, factory.int32NumericInstr("i32.or", [])]);
     case "And":
-      return ok([...left, ...right, factory.numericInstr("i32.and", [])]);
+      return ok([...left, ...right, factory.int32NumericInstr("i32.and", [])]);
     case "LessThan":
-      return ok([...left, ...right, factory.numericInstr("i32.lt_s", [])]);
+      return ok([...left, ...right, factory.int32NumericInstr("i32.lt_s", [])]);
     case "LessEqualThan":
-      return ok([...left, ...right, factory.numericInstr("i32.le_s", [])]);
+      return ok([...left, ...right, factory.int32NumericInstr("i32.le_s", [])]);
     case "GreaterThan":
-      return ok([...left, ...right, factory.numericInstr("i32.gt_s", [])]);
+      return ok([...left, ...right, factory.int32NumericInstr("i32.gt_s", [])]);
     case "GreaterEqualThan":
-      return ok([...left, ...right, factory.numericInstr("i32.ge_s", [])]);
+      return ok([...left, ...right, factory.int32NumericInstr("i32.ge_s", [])]);
     case "Equal":
-      return ok([...left, ...right, factory.numericInstr("i32.eq", [])]);
+      return ok([...left, ...right, factory.int32NumericInstr("i32.eq", [])]);
     case "NotEqual":
-      return ok([...left, ...right, factory.numericInstr("i32.ne", [])]);
+      return ok([...left, ...right, factory.int32NumericInstr("i32.ne", [])]);
     case "FAdd": // TODO
     case "FSub": // TODO
     case "FMultiply": // TODO

--- a/src/compiler/compile-node/binary-expression.ts
+++ b/src/compiler/compile-node/binary-expression.ts
@@ -2,6 +2,7 @@ import { mapValue, ok, error, Result } from "../../structure";
 import { BinaryOperation } from "../../syntax";
 import { CompileNodeFn, CompilationValue } from "../types";
 import { factory, InstructionNode } from "../../wasm";
+import { getFloatValueInstr, storeFloatValueInstr } from "../assets/modules/float";
 
 function getOperationInstr(
   left: CompilationValue,
@@ -57,16 +58,46 @@ function getOperationInstr(
       return ok([...left, ...right, factory.int32NumericInstr("i32.eq", [])]);
     case "NotEqual":
       return ok([...left, ...right, factory.int32NumericInstr("i32.ne", [])]);
-    case "FAdd": // TODO
-    case "FSub": // TODO
-    case "FMultiply": // TODO
+    case "FAdd":
+      return ok([
+        ...left,
+        ...getFloatValueInstr(),
+        ...right,
+        ...getFloatValueInstr(),
+        factory.float64NumericInstr("f64.add", []),
+        ...storeFloatValueInstr(),
+      ]);
+    case "FSub":
+      return ok([
+        ...left,
+        ...getFloatValueInstr(),
+        ...right,
+        ...getFloatValueInstr(),
+        factory.float64NumericInstr("f64.sub", []),
+        ...storeFloatValueInstr(),
+      ]);
+    case "FMultiply":
+      return ok([
+        ...left,
+        ...getFloatValueInstr(),
+        ...right,
+        ...getFloatValueInstr(),
+        factory.float64NumericInstr("f64.mul", []),
+        ...storeFloatValueInstr(),
+      ]);
     default:
+      // @ts-expect-error
       return error({ message: `invalid kind: ${op.kind}` });
   }
 }
 
-export const binaryExpression: CompileNodeFn<"BinaryExpression"> = (node, ctx, next) =>
-  mapValue(
+export const binaryExpression: CompileNodeFn<"BinaryExpression"> = (node, ctx, next) => {
+  const opKind = node.op.kind;
+  if (opKind === "FAdd" || opKind === "FSub" || opKind === "FMultiply") {
+    ctx.useFloat();
+  }
+  return mapValue(
     next(node.left, ctx),
     next(node.right, ctx),
   )((left, right) => getOperationInstr(left, right, node.op).error(err => ({ ...err, occurence: node })));
+};

--- a/src/compiler/compile-node/binary-expression.ts
+++ b/src/compiler/compile-node/binary-expression.ts
@@ -1,41 +1,72 @@
-import { ok, error, all, Result } from "../../structure";
-import { BinaryExpressionNode } from "../../syntax";
-import { CompileNodeFn } from "../types";
+import { mapValue, ok, error, Result } from "../../structure";
+import { BinaryOperation } from "../../syntax";
+import { CompileNodeFn, CompilationValue } from "../types";
 import { factory, InstructionNode } from "../../wasm";
 
-function getOperationInstr(node: BinaryExpressionNode): Result<readonly InstructionNode[]> {
-  switch (node.op.kind) {
+function getOperationInstr(
+  left: CompilationValue,
+  right: CompilationValue,
+  op: BinaryOperation,
+): Result<readonly InstructionNode[]> {
+  switch (op.kind) {
     case "Add":
-      return ok([factory.numericInstr("i32.add", [])]);
+      // 2(a + b) + 1 = (2a + 1) + (2b + 1) - 1 = A + B - 1
+      return ok([
+        ...left,
+        ...right,
+        factory.numericInstr("i32.add", []),
+        factory.numericInstr("i32.const", [factory.int32(1)]),
+        factory.numericInstr("i32.sub", []),
+      ]);
     case "Sub":
-      return ok([factory.numericInstr("i32.sub", [])]);
-    case "Multiply":
-      return ok([factory.numericInstr("i32.mul", [])]);
-    case "LessThan":
-      return ok([factory.numericInstr("i32.lt_s", [])]);
-    case "LessEqualThan":
-      return ok([factory.numericInstr("i32.le_s", [])]);
-    case "GreaterThan":
-      return ok([factory.numericInstr("i32.gt_s", [])]);
-    case "GreaterEqualThan":
-      return ok([factory.numericInstr("i32.ge_s", [])]);
+      // 2(a - b) + 1 = (2a + 1) - (2b + 1) + 1 = A - B + 1
+      return ok([
+        ...left,
+        ...right,
+        factory.numericInstr("i32.sub", []),
+        factory.numericInstr("i32.const", [factory.int32(1)]),
+        factory.numericInstr("i32.add", []),
+      ]);
+    case "Multiply": {
+      // 2ab + 1 = (2a + 1 - 1) * b  + 1 = (A - 1) * (B >> 1) + 1
+      return ok([
+        ...left,
+        factory.numericInstr("i32.const", [factory.int32(1)]),
+        factory.numericInstr("i32.sub", []),
+        ...right,
+        factory.numericInstr("i32.const", [factory.int32(1)]),
+        factory.numericInstr("i32.shr_s", []),
+        factory.numericInstr("i32.mul", []),
+        factory.numericInstr("i32.const", [factory.int32(1)]),
+        factory.numericInstr("i32.add", []),
+      ]);
+    }
     case "Or":
-      return ok([factory.numericInstr("i32.or", [])]);
+      return ok([...left, ...right, factory.numericInstr("i32.or", [])]);
     case "And":
-      return ok([factory.numericInstr("i32.and", [])]);
-    case "Equal": // FIXME
-      return ok([factory.numericInstr("i32.eq", [])]);
+      return ok([...left, ...right, factory.numericInstr("i32.and", [])]);
+    case "LessThan":
+      return ok([...left, ...right, factory.numericInstr("i32.lt_s", [])]);
+    case "LessEqualThan":
+      return ok([...left, ...right, factory.numericInstr("i32.le_s", [])]);
+    case "GreaterThan":
+      return ok([...left, ...right, factory.numericInstr("i32.gt_s", [])]);
+    case "GreaterEqualThan":
+      return ok([...left, ...right, factory.numericInstr("i32.ge_s", [])]);
+    case "Equal":
+      return ok([...left, ...right, factory.numericInstr("i32.eq", [])]);
     case "NotEqual":
-      return ok([factory.numericInstr("i32.ne", [])]);
+      return ok([...left, ...right, factory.numericInstr("i32.ne", [])]);
+    case "FAdd": // TODO
+    case "FSub": // TODO
+    case "FMultiply": // TODO
     default:
-      // @ts-expect-error
-      return error({ message: `invalid kind: ${node.op.kind}` });
+      return error({ message: `invalid kind: ${op.kind}` });
   }
 }
 
 export const binaryExpression: CompileNodeFn<"BinaryExpression"> = (node, ctx, next) =>
-  all([
+  mapValue(
     next(node.left, ctx),
     next(node.right, ctx),
-    getOperationInstr(node).error(err => ({ ...err, occurence: node })),
-  ]).map(lr => lr.flat());
+  )((left, right) => getOperationInstr(left, right, node.op).error(err => ({ ...err, occurence: node })));

--- a/src/compiler/compile-node/bool-literal.ts
+++ b/src/compiler/compile-node/bool-literal.ts
@@ -3,4 +3,4 @@ import { CompileNodeFn } from "../types";
 import { factory } from "../../wasm";
 
 export const boolLiteral: CompileNodeFn<"BoolLiteral"> = ({ value }) =>
-  ok([factory.numericInstr("i32.const", [factory.int32(value ? 1 : 0)])]);
+  ok([factory.int32NumericInstr("i32.const", [factory.int32(value ? 1 : 0)])]);

--- a/src/compiler/compile-node/float-literal.ts
+++ b/src/compiler/compile-node/float-literal.ts
@@ -1,0 +1,11 @@
+import { ok } from "../../structure";
+import { CompileNodeFn } from "../types";
+import { factory } from "../../wasm";
+
+export const floatLiteral: CompileNodeFn<"FloatLiteral"> = ({ value }, ctx) => {
+  ctx.useFloat();
+  return ok([
+    factory.float64NumericInstr("f64.const", [factory.float64(value)]),
+    factory.controlInstr("call", [factory.identifier("__float_new__")]),
+  ]);
+};

--- a/src/compiler/compile-node/function-application.ts
+++ b/src/compiler/compile-node/function-application.ts
@@ -2,7 +2,7 @@ import { mapValue, ok } from "../../structure";
 import { CompileNodeFn } from "../types";
 import { factory } from "../../wasm";
 import { newEnvInstr } from "../assets/modules/env";
-import { getTupleValueInstr } from "../assets/modules/tuple";
+import { getClosureEnvInstr, getClosureFuncBodyInstr } from "./macro/closure";
 
 export const functionApplication: CompileNodeFn<"FunctionApplication"> = (node, ctx, next) => {
   ctx.useEnvironment();
@@ -18,7 +18,7 @@ export const functionApplication: CompileNodeFn<"FunctionApplication"> = (node, 
       factory.variableInstr("local.set", [factory.identifier("prev_closure_addr")]),
       ...closureInstr,
       factory.variableInstr("local.tee", [factory.identifier("closure_addr")]),
-      ...getTupleValueInstr(0), // env for the closure is stored as the 1st value
+      ...getClosureEnvInstr(),
 
       // Note
       // bind the closure's own  address for recursive call
@@ -29,7 +29,7 @@ export const functionApplication: CompileNodeFn<"FunctionApplication"> = (node, 
       ...newEnvInstr(),
 
       factory.variableInstr("local.get", [factory.identifier("closure_addr")]),
-      ...getTupleValueInstr(1), // function body index for the closure is stored as the 2nd value
+      ...getClosureFuncBodyInstr(),
       ...ctx.funcDefStack.callInstr(),
       factory.variableInstr("local.get", [factory.identifier("prev_closure_addr")]),
       factory.variableInstr("local.set", [factory.identifier("closure_addr")]),

--- a/src/compiler/compile-node/int-literal.ts
+++ b/src/compiler/compile-node/int-literal.ts
@@ -1,6 +1,7 @@
 import { ok } from "../../structure";
 import { CompileNodeFn } from "../types";
 import { factory } from "../../wasm";
+import { fromNumber2IntBase } from "../js-bindings";
 
 export const intLiteral: CompileNodeFn<"IntLiteral"> = ({ value }) =>
-  ok([factory.numericInstr("i32.const", [factory.int32(value)])]);
+  ok([factory.numericInstr("i32.const", [factory.int32(fromNumber2IntBase(value))])]);

--- a/src/compiler/compile-node/int-literal.ts
+++ b/src/compiler/compile-node/int-literal.ts
@@ -4,4 +4,4 @@ import { factory } from "../../wasm";
 import { fromNumber2IntBase } from "../js-bindings";
 
 export const intLiteral: CompileNodeFn<"IntLiteral"> = ({ value }) =>
-  ok([factory.numericInstr("i32.const", [factory.int32(fromNumber2IntBase(value))])]);
+  ok([factory.int32NumericInstr("i32.const", [factory.int32(fromNumber2IntBase(value))])]);

--- a/src/compiler/compile-node/macro/closure.ts
+++ b/src/compiler/compile-node/macro/closure.ts
@@ -10,6 +10,10 @@ export function newClosureInstr(ctx: CompilationContext) {
     // Note
     // Function closure is represented as a tuple:
     //   (recursive_flag, env_address, function_index_of_table_elements)
-    return [...getEnvAddrInstr(), factory.numericInstr("i32.const", [factory.int32(funcIndex)]), ...newTupleInstr()];
+    return [
+      ...getEnvAddrInstr(),
+      factory.int32NumericInstr("i32.const", [factory.int32(funcIndex)]),
+      ...newTupleInstr(),
+    ];
   };
 }

--- a/src/compiler/compile-node/macro/closure.ts
+++ b/src/compiler/compile-node/macro/closure.ts
@@ -1,19 +1,43 @@
 import { factory } from "../../../wasm";
 import { getEnvAddrInstr } from "../../assets/modules/env";
-import { newTupleInstr } from "../../assets/modules/tuple";
+import { newTupleInstr, getTupleValueInstr } from "../../assets/modules/tuple";
 import { CompilationContext } from "../../types";
 
 export function newClosureInstr(ctx: CompilationContext) {
   ctx.useEnvironment();
   ctx.useTuple();
   return (funcIndex: number) => {
-    // Note
-    // Function closure is represented as a tuple:
-    //   (recursive_flag, env_address, function_index_of_table_elements)
     return [
+      // Note
+      // Function closure is represented as a tuple:
+      //   (recursive_flag, env_address, function_index_of_table_elements)
       ...getEnvAddrInstr(),
       factory.int32NumericInstr("i32.const", [factory.int32(funcIndex)]),
       ...newTupleInstr(),
+
+      // Note:
+      // We should add the following tag to LSB 4-bits of the closure address.
+      // [1110] = 0xd
+      factory.int32NumericInstr("i32.const", [factory.int32(4)]),
+      factory.int32NumericInstr("i32.shl"),
+      factory.int32NumericInstr("i32.const", [factory.int32(14)]),
+      factory.int32NumericInstr("i32.or"),
     ];
   };
+}
+
+export function getClosureEnvInstr() {
+  return [
+    factory.int32NumericInstr("i32.const", [factory.int32(4)]),
+    factory.int32NumericInstr("i32.shr_u"),
+    ...getTupleValueInstr(0), // env for the closure is stored as the 1st value
+  ];
+}
+
+export function getClosureFuncBodyInstr() {
+  return [
+    factory.int32NumericInstr("i32.const", [factory.int32(4)]),
+    factory.int32NumericInstr("i32.shr_u"),
+    ...getTupleValueInstr(1), // function body index for the closure is stored as the 2nd value
+  ];
 }

--- a/src/compiler/compile-node/match-pattern.ts
+++ b/src/compiler/compile-node/match-pattern.ts
@@ -53,7 +53,7 @@ export const matchPattern = createTreeTraverser<MatchPatternNode, CompilationCon
             factory.variableInstr("local.set", [factory.identifier("value")]),
             ...tailInstr,
           ],
-          [factory.numericInstr("i32.const", [factory.int32(0)])],
+          [factory.int32NumericInstr("i32.const", [factory.int32(0)])],
         ),
       ]);
     });

--- a/src/compiler/compile-node/unary-expression.ts
+++ b/src/compiler/compile-node/unary-expression.ts
@@ -6,4 +6,6 @@ export const unaryExpression: CompileNodeFn<"UnaryExpression"> = (node, ctx, nex
     ...instructions,
     factory.numericInstr("i32.const", [factory.int32(-1)]),
     factory.numericInstr("i32.mul", []),
+    factory.numericInstr("i32.const", [factory.int32(2)]),
+    factory.numericInstr("i32.add", []),
   ]);

--- a/src/compiler/compile-node/unary-expression.ts
+++ b/src/compiler/compile-node/unary-expression.ts
@@ -4,8 +4,8 @@ import { factory } from "../../wasm";
 export const unaryExpression: CompileNodeFn<"UnaryExpression"> = (node, ctx, next) =>
   next(node.exp, ctx).map(instructions => [
     ...instructions,
-    factory.numericInstr("i32.const", [factory.int32(-1)]),
-    factory.numericInstr("i32.mul", []),
-    factory.numericInstr("i32.const", [factory.int32(2)]),
-    factory.numericInstr("i32.add", []),
+    factory.int32NumericInstr("i32.const", [factory.int32(-1)]),
+    factory.int32NumericInstr("i32.mul", []),
+    factory.int32NumericInstr("i32.const", [factory.int32(2)]),
+    factory.int32NumericInstr("i32.add", []),
   ]);

--- a/src/compiler/compile-node/unary-expression.ts
+++ b/src/compiler/compile-node/unary-expression.ts
@@ -1,11 +1,25 @@
 import { CompileNodeFn } from "../types";
 import { factory } from "../../wasm";
+import { storeFloatValueInstr, getFloatValueInstr } from "../assets/modules/float";
 
-export const unaryExpression: CompileNodeFn<"UnaryExpression"> = (node, ctx, next) =>
-  next(node.exp, ctx).map(instructions => [
-    ...instructions,
-    factory.int32NumericInstr("i32.const", [factory.int32(-1)]),
-    factory.int32NumericInstr("i32.mul", []),
-    factory.int32NumericInstr("i32.const", [factory.int32(2)]),
-    factory.int32NumericInstr("i32.add", []),
-  ]);
+export const unaryExpression: CompileNodeFn<"UnaryExpression"> = (node, ctx, next) => {
+  const { kind } = node.op;
+  if (kind === "Minus") {
+    return next(node.exp, ctx).map(instructions => [
+      ...instructions,
+      factory.int32NumericInstr("i32.const", [factory.int32(-1)]),
+      factory.int32NumericInstr("i32.mul", []),
+      factory.int32NumericInstr("i32.const", [factory.int32(2)]),
+      factory.int32NumericInstr("i32.add", []),
+    ]);
+  } else {
+    ctx.useFloat();
+    return next(node.exp, ctx).map(instructions => [
+      ...instructions,
+      ...getFloatValueInstr(),
+      factory.float64NumericInstr("f64.const", [factory.float64(-1)]),
+      factory.float64NumericInstr("f64.mul", []),
+      ...storeFloatValueInstr(),
+    ]);
+  }
+};

--- a/src/compiler/compiler-context.ts
+++ b/src/compiler/compiler-context.ts
@@ -2,6 +2,7 @@ import { InstructionNode, LocalVarNode } from "../wasm";
 import { CompilationContext, Environment } from "./types";
 import { ModuleDefinition } from "./module-builder";
 import { getAllocatorModuleDefinition } from "./assets/modules/alloc";
+import { getFloatModuleDefinition } from "./assets/modules/float";
 import { getListModuleDefinition } from "./assets/modules/list";
 import { getTupleModuleDefinition } from "./assets/modules/tuple";
 import { getEnvModuleDefinition, localVarTypeForEnv, initEnvInstr } from "./assets/modules/env";
@@ -14,6 +15,7 @@ export class Context implements CompilationContext {
   private _env: Environment = createRootEnvironment();
   private _instructions: InstructionNode[] = [];
   private _enabledAllocator = false;
+  private _enabledFloat = false;
   private _enabledList = false;
   private _enabledTuple = false;
   private _enabledEnv = false;
@@ -68,6 +70,12 @@ export class Context implements CompilationContext {
     if (this._enabledAllocator) return;
     this._enabledAllocator = true;
     this._dependencies.push(getAllocatorModuleDefinition());
+  }
+
+  useFloat() {
+    if (this._enabledFloat) return;
+    this._enabledFloat = true;
+    this._dependencies.push(getFloatModuleDefinition());
   }
 
   useList() {

--- a/src/compiler/compiler.test.ts
+++ b/src/compiler/compiler.test.ts
@@ -46,19 +46,11 @@ describe(compile, () => {
       expect(await evaluateMain("1.0 *. 3.0", toFloat)).toBe(3.0);
     });
 
-    it("should compile numeric compare operation", async () => {
-      expect(await evaluateMain("1>0", toBoolean)).toBe(true);
-      expect(await evaluateMain("1>1", toBoolean)).toBe(false);
-      expect(await evaluateMain("1>2", toBoolean)).toBe(false);
+    it("should compile compare operation", async () => {
       expect(await evaluateMain("0<1", toBoolean)).toBe(true);
-      expect(await evaluateMain("1<1", toBoolean)).toBe(false);
-      expect(await evaluateMain("2<1", toBoolean)).toBe(false);
-      expect(await evaluateMain("1>=0", toBoolean)).toBe(true);
-      expect(await evaluateMain("1>=1", toBoolean)).toBe(true);
-      expect(await evaluateMain("1>=2", toBoolean)).toBe(false);
-      expect(await evaluateMain("0<=1", toBoolean)).toBe(true);
-      expect(await evaluateMain("1<=1", toBoolean)).toBe(true);
-      expect(await evaluateMain("2<=1", toBoolean)).toBe(false);
+      expect(await evaluateMain("0.<1.", toBoolean)).toBe(true);
+      expect(await evaluateMain("false < true.", toBoolean)).toBe(true);
+      expect(await evaluateMain("[] < false:[].", toBoolean)).toBe(true);
     });
 
     it("should compile logical operation", async () => {

--- a/src/compiler/compiler.test.ts
+++ b/src/compiler/compiler.test.ts
@@ -31,10 +31,16 @@ describe(compile, () => {
   });
 
   describe("binary expression", () => {
-    it("should compile arithmetic operations", async () => {
+    it("should compile integer arithmetic operations", async () => {
       expect(await evaluateMain("1+1")).toBe(2);
       expect(await evaluateMain("1-2")).toBe(-1);
       expect(await evaluateMain("1*3")).toBe(3);
+    });
+
+    it("should compile floating number arithmetic operations", async () => {
+      expect(await evaluateMain("1.0 +. 1.0", toFloat)).toBe(2.0);
+      expect(await evaluateMain("1.0 -. 2.0", toFloat)).toBe(-1.0);
+      expect(await evaluateMain("1.0 *. 3.0", toFloat)).toBe(3.0);
     });
 
     it("should compile numeric compare operation", async () => {

--- a/src/compiler/compiler.test.ts
+++ b/src/compiler/compiler.test.ts
@@ -49,8 +49,8 @@ describe(compile, () => {
     it("should compile compare operation", async () => {
       expect(await evaluateMain("0<1", toBoolean)).toBe(true);
       expect(await evaluateMain("0.<1.", toBoolean)).toBe(true);
-      expect(await evaluateMain("false < true.", toBoolean)).toBe(true);
-      expect(await evaluateMain("[] < false:[].", toBoolean)).toBe(true);
+      expect(await evaluateMain("false < true", toBoolean)).toBe(true);
+      expect(await evaluateMain("[] < false::[]", toBoolean)).toBe(true);
     });
 
     it("should compile logical operation", async () => {

--- a/src/compiler/compiler.test.ts
+++ b/src/compiler/compiler.test.ts
@@ -1,18 +1,18 @@
 import { parse } from "../syntax";
 import { generateBinary } from "../wasm";
 import { compile } from "./compiler";
-import { toNumber, toBoolean, toList } from "./js-bindings";
+import { toNumber, toBoolean, toListAnd, toList } from "./js-bindings";
 
 describe(compile, () => {
   describe("literal", () => {
     it("should comiple int literal", async () => {
-      expect(await evaluateMain("0")).toBe(0);
-      expect(await evaluateMain("1")).toBe(1);
+      expect(await evaluateMain("0", toNumber)).toBe(0);
+      expect(await evaluateMain("1", toNumber)).toBe(1);
     });
 
-    it("should comiple bool literal as 1 or 0", async () => {
-      expect(await evaluateMain("true")).toBe(1);
-      expect(await evaluateMain("false")).toBe(0);
+    it("should comiple bool literal", async () => {
+      expect(await evaluateMain("true", toBoolean)).toBe(true);
+      expect(await evaluateMain("false", toBoolean)).toBe(false);
     });
 
     it("should comiple empty list as 0", async () => {
@@ -22,8 +22,7 @@ describe(compile, () => {
 
   describe("unary expression", () => {
     it("should compile minus operation", async () => {
-      expect(await evaluateMain("-1")).toBe(-1);
-      expect(await evaluateMain("-true")).toBe(-1);
+      expect(await evaluateMain("-1", toNumber)).toBe(-1);
     });
   });
 
@@ -85,9 +84,9 @@ describe(compile, () => {
 
   describe("list constructor", () => {
     it("shuld compile list construction", async () => {
-      expect(await evaluateMain("1::[]", toList)).toEqual([1]);
-      expect(await evaluateMain("1::2::[]", toList)).toEqual([1, 2]);
-      expect(await evaluateMain("true::false::[]", toList)).toEqual([1, 0]);
+      expect(await evaluateMain("1::[]", toListAnd(toNumber))).toEqual([1]);
+      expect(await evaluateMain("1::2::[]", toListAnd(toNumber))).toEqual([1, 2]);
+      expect(await evaluateMain("true::false::[]", toListAnd(toBoolean))).toEqual([true, false]);
     });
   });
 
@@ -145,7 +144,7 @@ describe(compile, () => {
         let rec map = fun f -> fun list -> match list with [] -> [] | x::y -> (f x)::(map f y) in
         map twice (1::2::3::[])
       `;
-      expect(await evaluateMain(code, toList)).toEqual([2, 4, 6]);
+      expect(await evaluateMain(code, toListAnd(toNumber))).toEqual([2, 4, 6]);
     });
 
     test("factorial for list", async () => {
@@ -155,7 +154,7 @@ describe(compile, () => {
         let rec map = fun f -> fun list -> match list with [] -> [] | x::y -> (f x)::(map f y) in
         map fact (range 1 7)
       `;
-      expect(await evaluateMain(code, toList)).toEqual([1, 2, 6, 24, 120, 720]);
+      expect(await evaluateMain(code, toListAnd(toNumber))).toEqual([1, 2, 6, 24, 120, 720]);
     });
   });
 });

--- a/src/compiler/compiler.test.ts
+++ b/src/compiler/compiler.test.ts
@@ -25,8 +25,11 @@ describe(compile, () => {
   });
 
   describe("unary expression", () => {
-    it("should compile minus operation", async () => {
+    it("should compile integer minus operation", async () => {
       expect(await evaluateMain("-1", toNumber)).toBe(-1);
+    });
+    it("should compile floating minus operation", async () => {
+      expect(await evaluateMain("-.1.", toFloat)).toBe(-1);
     });
   });
 

--- a/src/compiler/compiler.test.ts
+++ b/src/compiler/compiler.test.ts
@@ -10,7 +10,7 @@ describe(compile, () => {
       expect(await evaluateMain("1", toNumber)).toBe(1);
     });
 
-    it("should comiple int literal", async () => {
+    it("should comiple float literal", async () => {
       expect(await evaluateMain("1.0", toFloat)).toBe(1.0);
     });
 

--- a/src/compiler/compiler.test.ts
+++ b/src/compiler/compiler.test.ts
@@ -1,13 +1,17 @@
 import { parse } from "../syntax";
 import { generateBinary } from "../wasm";
 import { compile } from "./compiler";
-import { toNumber, toBoolean, toListAnd, toList } from "./js-bindings";
+import { toNumber, toFloat, toBoolean, toListAnd, toList } from "./js-bindings";
 
 describe(compile, () => {
   describe("literal", () => {
     it("should comiple int literal", async () => {
       expect(await evaluateMain("0", toNumber)).toBe(0);
       expect(await evaluateMain("1", toNumber)).toBe(1);
+    });
+
+    it("should comiple int literal", async () => {
+      expect(await evaluateMain("1.0", toFloat)).toBe(1.0);
     });
 
     it("should comiple bool literal", async () => {

--- a/src/compiler/compiler.ts
+++ b/src/compiler/compiler.ts
@@ -1,4 +1,4 @@
-import { createTreeTraverser } from "../structure";
+import { createTreeTraverser, error } from "../structure";
 import { factory } from "../wasm";
 import { ExpressionNode } from "../syntax";
 import { CompilationContext, CompilationResult, CompiledModuleResult } from "./types";
@@ -23,6 +23,7 @@ const traverse = createTreeTraverser<ExpressionNode, CompilationContext, Compila
   boolLiteral,
   emptyList,
   intLiteral,
+  floatLiteral: node => error({ message: "TODO: should be implemented", occurence: node }),
   unaryExpression,
   binaryExpression,
   listConstructor,

--- a/src/compiler/compiler.ts
+++ b/src/compiler/compiler.ts
@@ -1,4 +1,4 @@
-import { createTreeTraverser, error } from "../structure";
+import { createTreeTraverser } from "../structure";
 import { factory } from "../wasm";
 import { ExpressionNode } from "../syntax";
 import { CompilationContext, CompilationResult, CompiledModuleResult } from "./types";
@@ -6,6 +6,7 @@ import { Context } from "./compiler-context";
 import { ModuleBuilder } from "./module-builder";
 
 import { intLiteral } from "./compile-node/int-literal";
+import { floatLiteral } from "./compile-node/float-literal";
 import { boolLiteral } from "./compile-node/bool-literal";
 import { emptyList } from "./compile-node/empty-list";
 import { unaryExpression } from "./compile-node/unary-expression";
@@ -23,7 +24,7 @@ const traverse = createTreeTraverser<ExpressionNode, CompilationContext, Compila
   boolLiteral,
   emptyList,
   intLiteral,
-  floatLiteral: node => error({ message: "TODO: should be implemented", occurence: node }),
+  floatLiteral,
   unaryExpression,
   binaryExpression,
   listConstructor,

--- a/src/compiler/js-bindings.ts
+++ b/src/compiler/js-bindings.ts
@@ -10,6 +10,11 @@ export function toNumber(_instance: WebAssembly.Instance, value: number) {
   return value >> 1;
 }
 
+export function toFloat(instance: WebAssembly.Instance, value: number) {
+  const getFloat = instance.exports["__float_get__"] as (addr: number) => number;
+  return getFloat(value);
+}
+
 export function toBoolean(_instance: WebAssembly.Instance, value: number) {
   return value ? true : false;
 }

--- a/src/compiler/types.ts
+++ b/src/compiler/types.ts
@@ -24,6 +24,7 @@ export interface DefinitionStack<T, S = number> {
 export interface CompilationContext {
   readonly pushInstruction: (instruction: InstructionNode | readonly InstructionNode[]) => void;
   readonly useAllocator: () => void;
+  readonly useFloat: () => void;
   readonly useList: () => void;
   readonly useTuple: () => void;
   readonly useEnvironment: () => void;

--- a/src/compiler/types.ts
+++ b/src/compiler/types.ts
@@ -29,6 +29,7 @@ export interface CompilationContext {
   readonly useTuple: () => void;
   readonly useEnvironment: () => void;
   readonly useMatcher: () => void;
+  readonly useComparator: (op: "lt" | "le" | "gt" | "ge") => void;
   readonly useLocalVar: (node: LocalVarNode) => void;
   readonly setEnv: (env: Environment) => void;
   readonly getEnv: () => Environment;

--- a/src/evaluate/comparetor.ts
+++ b/src/evaluate/comparetor.ts
@@ -1,0 +1,71 @@
+import { ok, error, mapValue, Result } from "../structure";
+import { ComparisonOperations } from "../syntax";
+import { EvaluationValue } from "./types";
+import { isClosure, isList } from "./utils";
+
+function deepEqual<T extends EvaluationValue>(left: T, right: T): Result<boolean> {
+  if (typeof left === "number" || typeof left === "boolean") {
+    return ok(left === right);
+  }
+  if (isList(left) && isList(right)) {
+    if (left.length !== right.length) return ok(false);
+    return mapValue(...left.map((x, i) => deepEqual(x, right[i])))((...values: boolean[]) => ok(values.every(x => x)));
+  }
+  if (isClosure(left) || isClosure(right)) {
+    return error({
+      message: "Invalid_argument compare: functional value",
+    });
+  }
+  return error({
+    message: "Type mismatch.",
+  });
+}
+
+export function compare(left: EvaluationValue, right: EvaluationValue, op: ComparisonOperations): Result<boolean> {
+  if (
+    (typeof left === "number" && typeof right === "number") ||
+    (typeof left === "boolean" && typeof right === "boolean")
+  ) {
+    switch (op.kind) {
+      case "LessThan":
+        return ok(left < right);
+      case "LessEqualThan":
+        return ok(left <= right);
+      case "GreaterThan":
+        return ok(left > right);
+      case "GreaterEqualThan":
+        return ok(left >= right);
+      case "Equal":
+        return ok(left === right);
+      case "NotEqual":
+        return ok(left !== right);
+      default:
+        // @ts-expect-error
+        throw new Error(`invalid operation: ${op.kind}`);
+    }
+  }
+  if (isClosure(left) || isClosure(right)) {
+    if (op.kind === "Equal") {
+      return ok(left === right);
+    } else if (op.kind === "NotEqual") {
+      return ok(left !== right);
+    }
+    return error({
+      message: "Invalid_argument compare: functional value",
+    });
+  }
+  if (isList(left) && isList(right)) {
+    if (op.kind === "Equal") {
+      return ok((left.length === 0 && right.length === 0) || left === right);
+    } else if (op.kind === "NotEqual") {
+      return ok((left.length !== 0 || right.length !== 0) && left !== right);
+    } else if (op.kind === "LessThan" || op.kind === "GreaterThan") {
+      return ok(false);
+    } else {
+      return deepEqual(left, right);
+    }
+  }
+  return error({
+    message: "Type mismatch.",
+  });
+}

--- a/src/evaluate/evaluate-node/binay-expression.ts
+++ b/src/evaluate/evaluate-node/binay-expression.ts
@@ -1,6 +1,7 @@
 import { mapValue } from "../../structure";
 import { EvaluateNodeFn } from "../types";
-import { map2num, map2bool, equal } from "../utils";
+import { map2num, map2bool } from "../utils";
+import { compare } from "../comparetor";
 
 export const binaryExpression: EvaluateNodeFn<"BinaryExpression"> = (expression, env, next) =>
   mapValue(
@@ -17,24 +18,17 @@ export const binaryExpression: EvaluateNodeFn<"BinaryExpression"> = (expression,
       case "Multiply":
       case "FMultiply":
         return map2num(left, right)((l, r) => l * r).error(err => ({ ...err, occurence: expression }));
-      case "LessThan":
-        return map2num(left, right)((l, r) => l < r).error(err => ({ ...err, occurence: expression }));
-      case "LessEqualThan":
-        return map2num(left, right)((l, r) => l <= r).error(err => ({ ...err, occurence: expression }));
-      case "GreaterThan":
-        return map2num(left, right)((l, r) => l > r).error(err => ({ ...err, occurence: expression }));
-      case "GreaterEqualThan":
-        return map2num(left, right)((l, r) => l >= r).error(err => ({ ...err, occurence: expression }));
       case "Or":
         return map2bool(left, right)((l, r) => l || r).error(err => ({ ...err, occurence: expression }));
       case "And":
         return map2bool(left, right)((l, r) => l && r).error(err => ({ ...err, occurence: expression }));
+      case "LessThan":
+      case "LessEqualThan":
+      case "GreaterThan":
+      case "GreaterEqualThan":
       case "Equal":
-        return equal(left, right).error(err => ({ ...err, occurence: expression }));
       case "NotEqual":
-        return equal(left, right)
-          .map(r => !r)
-          .error(err => ({ ...err, occurence: expression }));
+        return compare(left, right, expression.op).error(err => ({ ...err, occurence: expression }));
       default:
         // @ts-expect-error
         throw new Error(`invalid operation: ${expression.op.kind}`);

--- a/src/evaluate/evaluate-node/binay-expression.ts
+++ b/src/evaluate/evaluate-node/binay-expression.ts
@@ -9,10 +9,13 @@ export const binaryExpression: EvaluateNodeFn<"BinaryExpression"> = (expression,
   )((left, right) => {
     switch (expression.op.kind) {
       case "Add":
+      case "FAdd":
         return map2num(left, right)((l, r) => l + r).error(err => ({ ...err, occurence: expression }));
       case "Sub":
+      case "FSub":
         return map2num(left, right)((l, r) => l - r).error(err => ({ ...err, occurence: expression }));
       case "Multiply":
+      case "FMultiply":
         return map2num(left, right)((l, r) => l * r).error(err => ({ ...err, occurence: expression }));
       case "LessThan":
         return map2num(left, right)((l, r) => l < r).error(err => ({ ...err, occurence: expression }));

--- a/src/evaluate/evaluate-node/binay-expression.ts
+++ b/src/evaluate/evaluate-node/binay-expression.ts
@@ -1,7 +1,7 @@
 import { mapValue } from "../../structure";
 import { EvaluateNodeFn } from "../types";
 import { map2num, map2bool } from "../utils";
-import { compare } from "../comparetor";
+import { compare } from "./comparetor";
 
 export const binaryExpression: EvaluateNodeFn<"BinaryExpression"> = (expression, env, next) =>
   mapValue(

--- a/src/evaluate/evaluate-node/comparator.test.ts
+++ b/src/evaluate/evaluate-node/comparator.test.ts
@@ -1,0 +1,126 @@
+import { compare } from "./comparetor";
+import { LTOperation, LEOperation, GTOperation, GEOperation } from "../../syntax";
+
+const lt: LTOperation = {
+  kind: "LessThan",
+  token: {
+    tokenKind: "Symbol",
+    symbol: "<",
+  },
+};
+
+const le: LEOperation = {
+  kind: "LessEqualThan",
+  token: {
+    tokenKind: "Symbol",
+    symbol: "<=",
+  },
+};
+
+const gt: GTOperation = {
+  kind: "GreaterThan",
+  token: {
+    tokenKind: "Symbol",
+    symbol: ">",
+  },
+};
+
+const ge: GEOperation = {
+  kind: "GreaterEqualThan",
+  token: {
+    tokenKind: "Symbol",
+    symbol: ">=",
+  },
+};
+
+describe(compare, () => {
+  describe("with number operand", () => {
+    it("should be calc lt correctlry", () => {
+      expect(compare(1, 1, lt).unwrap()).toBe(false);
+      expect(compare(1, 0, lt).unwrap()).toBe(false);
+      expect(compare(0, 1, lt).unwrap()).toBe(true);
+    });
+
+    it("should be calc le correctlry", () => {
+      expect(compare(1, 1, le).unwrap()).toBe(true);
+      expect(compare(1, 0, le).unwrap()).toBe(false);
+      expect(compare(0, 1, le).unwrap()).toBe(true);
+    });
+
+    it("should be calc gt correctlry", () => {
+      expect(compare(1, 1, gt).unwrap()).toBe(false);
+      expect(compare(1, 0, gt).unwrap()).toBe(true);
+      expect(compare(0, 1, gt).unwrap()).toBe(false);
+    });
+
+    it("should be calc ge correctlry", () => {
+      expect(compare(1, 1, ge).unwrap()).toBe(true);
+      expect(compare(1, 0, ge).unwrap()).toBe(true);
+      expect(compare(0, 1, ge).unwrap()).toBe(false);
+    });
+  });
+
+  describe("with boolean comparison", () => {
+    it("should be calc lt correctlry", () => {
+      expect(compare(false, false, lt).unwrap()).toBe(false);
+      expect(compare(true, true, lt).unwrap()).toBe(false);
+      expect(compare(true, false, lt).unwrap()).toBe(false);
+      expect(compare(false, true, lt).unwrap()).toBe(true);
+    });
+
+    it("should be calc le correctlry", () => {
+      expect(compare(false, false, le).unwrap()).toBe(true);
+      expect(compare(true, true, le).unwrap()).toBe(true);
+      expect(compare(true, false, le).unwrap()).toBe(false);
+      expect(compare(false, true, le).unwrap()).toBe(true);
+    });
+
+    it("should be calc gt correctlry", () => {
+      expect(compare(false, false, gt).unwrap()).toBe(false);
+      expect(compare(true, true, gt).unwrap()).toBe(false);
+      expect(compare(true, false, gt).unwrap()).toBe(true);
+      expect(compare(false, true, gt).unwrap()).toBe(false);
+    });
+
+    it("should be calc ge correctlry", () => {
+      expect(compare(false, false, ge).unwrap()).toBe(true);
+      expect(compare(true, true, ge).unwrap()).toBe(true);
+      expect(compare(true, false, ge).unwrap()).toBe(true);
+      expect(compare(false, true, ge).unwrap()).toBe(false);
+    });
+  });
+
+  describe("with list comparison", () => {
+    it("should be calc lt correctlry", () => {
+      expect(compare([false], [], lt).unwrap()).toBe(false);
+      expect(compare([false], [false], lt).unwrap()).toBe(false);
+      expect(compare([true], [false], lt).unwrap()).toBe(false);
+      expect(compare([], [false], lt).unwrap()).toBe(true);
+      expect(compare([false, true], [true], lt).unwrap()).toBe(true);
+    });
+
+    it("should be calc le correctlry", () => {
+      expect(compare([false], [], le).unwrap()).toBe(false);
+      expect(compare([false], [false], le).unwrap()).toBe(true);
+      expect(compare([true], [false], le).unwrap()).toBe(false);
+      expect(compare([], [false], le).unwrap()).toBe(true);
+      expect(compare([false, true], [true], le).unwrap()).toBe(true);
+    });
+
+    it("should be calc gt correctlry", () => {
+      expect(compare([], [false], gt).unwrap()).toBe(false);
+      expect(compare([false], [false], gt).unwrap()).toBe(false);
+      expect(compare([false], [true], gt).unwrap()).toBe(false);
+      expect(compare([false], [], gt).unwrap()).toBe(true);
+      expect(compare([true], [false, true], gt).unwrap()).toBe(true);
+    });
+
+    it("should be calc ge correctlry", () => {
+      expect(compare([], [false], ge).unwrap()).toBe(false);
+      expect(compare([false], [false], ge).unwrap()).toBe(true);
+      expect(compare([false], [true], ge).unwrap()).toBe(false);
+      expect(compare([false], [], ge).unwrap()).toBe(true);
+      expect(compare([true], [false, true], ge).unwrap()).toBe(true);
+    });
+  });
+});

--- a/src/evaluate/evaluate-node/literal.ts
+++ b/src/evaluate/evaluate-node/literal.ts
@@ -1,4 +1,4 @@
 import { ok } from "../../structure";
 import { EvaluateNodeFn } from "../types";
 
-export const literal: EvaluateNodeFn<"BoolLiteral" | "IntLiteral"> = ({ value }) => ok(value);
+export const literal: EvaluateNodeFn<"BoolLiteral" | "IntLiteral" | "FloatLiteral"> = ({ value }) => ok(value);

--- a/src/evaluate/evaluator.test.ts
+++ b/src/evaluate/evaluator.test.ts
@@ -22,26 +22,6 @@ describe(evaluate, () => {
     expect(parseAndEval("1.1 +. 1.1")).toBe(2.2);
     expect(parseAndEval("1.1 -. 1.1")).toBe(0.0);
     expect(parseAndEval("2.0 *. 3.1")).toBe(6.2);
-
-    expect(parseAndEval("0 < 1")).toBe(true);
-    expect(parseAndEval("0.0 < 1.0")).toBe(true);
-    expect(parseAndEval("1 < 1")).toBe(false);
-    expect(parseAndEval("2 < 1")).toBe(false);
-
-    expect(parseAndEval("1 > 0")).toBe(true);
-    expect(parseAndEval("1.0 > 0.0")).toBe(true);
-    expect(parseAndEval("1 > 1")).toBe(false);
-    expect(parseAndEval("1 > 2")).toBe(false);
-
-    expect(parseAndEval("0 <= 1")).toBe(true);
-    expect(parseAndEval("0.0 <= 1.0")).toBe(true);
-    expect(parseAndEval("1 <= 1")).toBe(true);
-    expect(parseAndEval("2 <= 1")).toBe(false);
-
-    expect(parseAndEval("1 >= 0")).toBe(true);
-    expect(parseAndEval("1.0 >= 0.0")).toBe(true);
-    expect(parseAndEval("1 >= 1")).toBe(true);
-    expect(parseAndEval("1 >= 2")).toBe(false);
   });
 
   test("logical operation", () => {
@@ -56,7 +36,47 @@ describe(evaluate, () => {
     expect(parseAndEval("false && false")).toBe(false);
   });
 
-  test("equality", () => {
+  test("comparison", () => {
+    expect(parseAndEval("0 < 1")).toBe(true);
+    expect(parseAndEval("1 < 1")).toBe(false);
+    expect(parseAndEval("2 < 1")).toBe(false);
+
+    expect(parseAndEval("1 > 0")).toBe(true);
+    expect(parseAndEval("1 > 1")).toBe(false);
+    expect(parseAndEval("1 > 2")).toBe(false);
+
+    expect(parseAndEval("0 <= 1")).toBe(true);
+    expect(parseAndEval("1 <= 1")).toBe(true);
+    expect(parseAndEval("2 <= 1")).toBe(false);
+
+    expect(parseAndEval("1 >= 0")).toBe(true);
+    expect(parseAndEval("1 >= 1")).toBe(true);
+    expect(parseAndEval("1 >= 2")).toBe(false);
+
+    expect(parseAndEval("0.0 < 1.0")).toBe(true);
+    expect(parseAndEval("0.0 > 1.0")).toBe(false);
+    expect(parseAndEval("0.0 <= 1.0")).toBe(true);
+    expect(parseAndEval("0.0 >= 1.0")).toBe(false);
+    expect(parseAndEval("1.0 <= 1.0")).toBe(true);
+    expect(parseAndEval("1.0 >= 1.0")).toBe(true);
+
+    expect(parseAndEval("[] < []")).toBe(false);
+    expect(parseAndEval("[] > []")).toBe(false);
+    expect(parseAndEval("[] < 1::[]")).toBe(false);
+    expect(parseAndEval("[] > 1::[]")).toBe(false);
+    expect(parseAndEval("[] <= []")).toBe(true);
+    expect(parseAndEval("1::[] <= 1::[]")).toBe(true);
+    expect(parseAndEval("1::[] >= 1::[]")).toBe(true);
+    expect(parseAndEval("[] <= 1::[]")).toBe(false);
+    expect(parseAndEval("[] >= 1::[]")).toBe(false);
+
+    expect(parseAndEval("false < true")).toBe(true);
+    expect(parseAndEval("false > true")).toBe(false);
+    expect(parseAndEval("false <= true")).toBe(true);
+    expect(parseAndEval("false >= true")).toBe(false);
+    expect(parseAndEval("true <= true")).toBe(true);
+    expect(parseAndEval("true >= true")).toBe(true);
+
     expect(parseAndEval("1 == 0")).toBe(false);
     expect(parseAndEval("1 == 1")).toBe(true);
 

--- a/src/evaluate/evaluator.test.ts
+++ b/src/evaluate/evaluator.test.ts
@@ -38,44 +38,9 @@ describe(evaluate, () => {
 
   test("comparison", () => {
     expect(parseAndEval("0 < 1")).toBe(true);
-    expect(parseAndEval("1 < 1")).toBe(false);
-    expect(parseAndEval("2 < 1")).toBe(false);
-
-    expect(parseAndEval("1 > 0")).toBe(true);
-    expect(parseAndEval("1 > 1")).toBe(false);
-    expect(parseAndEval("1 > 2")).toBe(false);
-
-    expect(parseAndEval("0 <= 1")).toBe(true);
-    expect(parseAndEval("1 <= 1")).toBe(true);
-    expect(parseAndEval("2 <= 1")).toBe(false);
-
-    expect(parseAndEval("1 >= 0")).toBe(true);
-    expect(parseAndEval("1 >= 1")).toBe(true);
-    expect(parseAndEval("1 >= 2")).toBe(false);
-
     expect(parseAndEval("0.0 < 1.0")).toBe(true);
-    expect(parseAndEval("0.0 > 1.0")).toBe(false);
-    expect(parseAndEval("0.0 <= 1.0")).toBe(true);
-    expect(parseAndEval("0.0 >= 1.0")).toBe(false);
-    expect(parseAndEval("1.0 <= 1.0")).toBe(true);
-    expect(parseAndEval("1.0 >= 1.0")).toBe(true);
-
-    expect(parseAndEval("[] < []")).toBe(false);
-    expect(parseAndEval("[] > []")).toBe(false);
-    expect(parseAndEval("[] < 1::[]")).toBe(false);
-    expect(parseAndEval("[] > 1::[]")).toBe(false);
-    expect(parseAndEval("[] <= []")).toBe(true);
-    expect(parseAndEval("1::[] <= 1::[]")).toBe(true);
-    expect(parseAndEval("1::[] >= 1::[]")).toBe(true);
-    expect(parseAndEval("[] <= 1::[]")).toBe(false);
-    expect(parseAndEval("[] >= 1::[]")).toBe(false);
-
     expect(parseAndEval("false < true")).toBe(true);
-    expect(parseAndEval("false > true")).toBe(false);
-    expect(parseAndEval("false <= true")).toBe(true);
-    expect(parseAndEval("false >= true")).toBe(false);
-    expect(parseAndEval("true <= true")).toBe(true);
-    expect(parseAndEval("true >= true")).toBe(true);
+    expect(parseAndEval("[] < 1::[]")).toBe(true);
 
     expect(parseAndEval("1 == 0")).toBe(false);
     expect(parseAndEval("1 == 1")).toBe(true);

--- a/src/evaluate/evaluator.test.ts
+++ b/src/evaluate/evaluator.test.ts
@@ -19,19 +19,27 @@ describe(evaluate, () => {
     expect(parseAndEval("1 - 1")).toBe(0);
     expect(parseAndEval("2 * 3")).toBe(6);
 
+    expect(parseAndEval("1.1 +. 1.1")).toBe(2.2);
+    expect(parseAndEval("1.1 -. 1.1")).toBe(0.0);
+    expect(parseAndEval("2.0 *. 3.1")).toBe(6.2);
+
     expect(parseAndEval("0 < 1")).toBe(true);
+    expect(parseAndEval("0.0 < 1.0")).toBe(true);
     expect(parseAndEval("1 < 1")).toBe(false);
     expect(parseAndEval("2 < 1")).toBe(false);
 
     expect(parseAndEval("1 > 0")).toBe(true);
+    expect(parseAndEval("1.0 > 0.0")).toBe(true);
     expect(parseAndEval("1 > 1")).toBe(false);
     expect(parseAndEval("1 > 2")).toBe(false);
 
     expect(parseAndEval("0 <= 1")).toBe(true);
+    expect(parseAndEval("0.0 <= 1.0")).toBe(true);
     expect(parseAndEval("1 <= 1")).toBe(true);
     expect(parseAndEval("2 <= 1")).toBe(false);
 
     expect(parseAndEval("1 >= 0")).toBe(true);
+    expect(parseAndEval("1.0 >= 0.0")).toBe(true);
     expect(parseAndEval("1 >= 1")).toBe(true);
     expect(parseAndEval("1 >= 2")).toBe(false);
   });

--- a/src/evaluate/evaluator.ts
+++ b/src/evaluate/evaluator.ts
@@ -20,6 +20,7 @@ export function evaluate(expression: ExpressionNode) {
   return createTreeTraverser<ExpressionNode, Environment, EvaluationResult>({
     boolLiteral: literal,
     intLiteral: literal,
+    floatLiteral: literal,
     emptyList,
     identifier,
     functionDefinition,

--- a/src/evaluate/utils.ts
+++ b/src/evaluate/utils.ts
@@ -1,4 +1,4 @@
-import { Result, error, ok } from "../structure";
+import { error, ok } from "../structure";
 import { EvaluationValue, Closure, RecClosure, EvaluationList } from "./types";
 
 export function isList(value: EvaluationValue): value is EvaluationList {
@@ -13,19 +13,6 @@ export function isClosure(value: EvaluationValue): value is Closure {
 export function isRecClosure(value: EvaluationValue): value is RecClosure {
   if (isList(value)) return false;
   return typeof value === "object" && value.kind === "Closure" && value.closureModifier === "Recursive";
-}
-
-export function equal(left: EvaluationValue, right: EvaluationValue): Result<boolean> {
-  if (typeof left === "number" && typeof right === "number") return ok(left === right);
-  if (typeof left === "boolean" && typeof right === "boolean") return ok(left === right);
-  if (isList(left) && isList(right)) {
-    if (left.length === 0 && right.length === 0) return ok(true);
-    return ok(left === right);
-  }
-  if (isClosure(left) && isClosure(right)) return ok(left === right);
-  return error({
-    message: "Operand type mismatch.",
-  });
 }
 
 export function map2num(...operands: EvaluationValue[]) {

--- a/src/syntax/parser.test.ts
+++ b/src/syntax/parser.test.ts
@@ -3,9 +3,14 @@ import { parse } from "./parser";
 import {
   ExpressionNode,
   IntLiteralNode,
+  FloatLiteralNode,
   MinusOperation,
+  FMinusOperation,
   AddOperation,
   MultiplyOperation,
+  FAddOperation,
+  FSubOperation,
+  FMultiplyOperation,
   BoolLiteralNode,
   IdentifierNode,
   LTOperation,
@@ -18,7 +23,7 @@ import {
   NEOperation,
   SubOperation,
   EmptyListNode,
-} from "../syntax/types";
+} from "./types";
 
 const num = (value: number) =>
   ({
@@ -26,11 +31,25 @@ const num = (value: number) =>
     value,
   } as IntLiteralNode);
 
+const float = (value: number) =>
+  ({
+    kind: "FloatLiteral",
+    value,
+  } as FloatLiteralNode);
+
 const minus: MinusOperation = {
   kind: "Minus",
   token: {
     tokenKind: "Symbol",
     symbol: "-",
+  },
+};
+
+const fMinus: FMinusOperation = {
+  kind: "FMinus",
+  token: {
+    tokenKind: "Symbol",
+    symbol: "-.",
   },
 };
 
@@ -55,6 +74,30 @@ const multiply: MultiplyOperation = {
   token: {
     tokenKind: "Symbol",
     symbol: "*",
+  },
+};
+
+const fAdd: FAddOperation = {
+  kind: "FAdd",
+  token: {
+    tokenKind: "Symbol",
+    symbol: "+.",
+  },
+};
+
+const fSub: FSubOperation = {
+  kind: "FSub",
+  token: {
+    tokenKind: "Symbol",
+    symbol: "-.",
+  },
+};
+
+const fMultiply: FMultiplyOperation = {
+  kind: "FMultiply",
+  token: {
+    tokenKind: "Symbol",
+    symbol: "*.",
   },
 };
 
@@ -139,6 +182,7 @@ const expr = <T extends ExpressionNode = ExpressionNode>(node: T) => node;
 
 const fixture = {
   "0": () => num(0),
+  "0.": () => float(0),
   true: () => bool(true),
   false: () => bool(false),
   "-0": () =>
@@ -147,6 +191,12 @@ const fixture = {
       op: minus,
       exp: num(0),
     }),
+  "-.0.": () =>
+    expr({
+      kind: "UnaryExpression",
+      op: fMinus,
+      exp: float(0),
+    }),
   "1+2": () =>
     expr({
       kind: "BinaryExpression",
@@ -154,12 +204,26 @@ const fixture = {
       left: num(1),
       right: num(2),
     }),
+  "1.+.2.": () =>
+    expr({
+      kind: "BinaryExpression",
+      op: fAdd,
+      left: float(1.0),
+      right: float(2.0),
+    }),
   "1-2": () =>
     expr({
       kind: "BinaryExpression",
       op: sub,
       left: num(1),
       right: num(2),
+    }),
+  "1.-.2.": () =>
+    expr({
+      kind: "BinaryExpression",
+      op: fSub,
+      left: float(1.0),
+      right: float(2.0),
     }),
   "1+2*3": () =>
     expr({
@@ -184,6 +248,18 @@ const fixture = {
         right: num(2),
       },
       right: num(3),
+    }),
+  "1.*.2.+.3.": () =>
+    expr({
+      kind: "BinaryExpression",
+      op: fAdd,
+      left: {
+        kind: "BinaryExpression",
+        op: fMultiply,
+        left: float(1.0),
+        right: float(2.0),
+      },
+      right: float(3.0),
     }),
   "(1+2)*3": () =>
     expr({

--- a/src/syntax/parser.ts
+++ b/src/syntax/parser.ts
@@ -20,7 +20,7 @@ import {
   MatchExpressionNode,
   MatchPatternElementNode,
 } from "./types";
-import { symbolToken, numberToken, keywordToken, variableToken } from "./tokenizer";
+import { symbolToken, integerToken, keywordToken, variableToken } from "./tokenizer";
 
 /**
  *
@@ -397,7 +397,7 @@ const bool: Parser<BoolLiteralNode> = oneOf(
   ),
 );
 
-const num: Parser<IntLiteralNode> = expect(numberToken)(({ value, loc }) => ({
+const num: Parser<IntLiteralNode> = expect(integerToken)(({ value, loc }) => ({
   kind: "IntLiteral",
   value,
   loc,

--- a/src/syntax/parser.ts
+++ b/src/syntax/parser.ts
@@ -43,7 +43,7 @@ import { symbolToken, integerToken, keywordToken, variableToken, decimalToken } 
  * mul          ::= prfx(("*" | "*.") (prfx | cond | match | func | bind))*
  * prfx         ::= app | ("-" | "-.") app
  * app          ::= prim (prim)*
- * prim         ::= id | bool | int | empty | group
+ * prim         ::= id | bool | int | decimal | empty | group
  * group        ::= "(" expr ")"
  * empty        ::= "[" "]"
  * bool         ::= "true" | "false"

--- a/src/syntax/tokenizer.test.ts
+++ b/src/syntax/tokenizer.test.ts
@@ -19,13 +19,13 @@ test(integerToken.name, () => {
 
 test(decimalToken.name, () => {
   expect(decimalToken(new Scanner("0.")).unwrap()).toMatchObject<Omit<Token, "value">>({
-    tokenKind: "Float",
+    tokenKind: "Decimal",
   });
   expect(decimalToken(new Scanner("01.")).unwrap()).toMatchObject<Omit<Token, "value">>({
-    tokenKind: "Float",
+    tokenKind: "Decimal",
   });
   expect(decimalToken(new Scanner("2.0")).unwrap()).toMatchObject<Omit<Token, "value">>({
-    tokenKind: "Float",
+    tokenKind: "Decimal",
   });
   expect(Math.floor(decimalToken(new Scanner("2.0")).unwrap().value)).toBe(2);
 });

--- a/src/syntax/tokenizer.test.ts
+++ b/src/syntax/tokenizer.test.ts
@@ -1,4 +1,4 @@
-import { integerToken, variableToken, keywordToken } from "./tokenizer";
+import { integerToken, decimalToken, variableToken, keywordToken } from "./tokenizer";
 import { Scanner } from "../parser-util";
 import { Token } from "./types";
 
@@ -15,6 +15,19 @@ test(integerToken.name, () => {
     tokenKind: "Integer",
     value: 20,
   });
+});
+
+test(decimalToken.name, () => {
+  expect(decimalToken(new Scanner("0.")).unwrap()).toMatchObject<Omit<Token, "value">>({
+    tokenKind: "Float",
+  });
+  expect(decimalToken(new Scanner("01.")).unwrap()).toMatchObject<Omit<Token, "value">>({
+    tokenKind: "Float",
+  });
+  expect(decimalToken(new Scanner("2.0")).unwrap()).toMatchObject<Omit<Token, "value">>({
+    tokenKind: "Float",
+  });
+  expect(Math.floor(decimalToken(new Scanner("2.0")).unwrap().value)).toBe(2);
 });
 
 test(keywordToken.name, () => {

--- a/src/syntax/tokenizer.test.ts
+++ b/src/syntax/tokenizer.test.ts
@@ -1,17 +1,17 @@
-import { numberToken, variableToken, keywordToken } from "./tokenizer";
+import { integerToken, variableToken, keywordToken } from "./tokenizer";
 import { Scanner } from "../parser-util";
 import { Token } from "./types";
 
-test(numberToken.name, () => {
-  expect(numberToken(new Scanner("0")).unwrap()).toMatchObject<Token>({
+test(integerToken.name, () => {
+  expect(integerToken(new Scanner("0")).unwrap()).toMatchObject<Token>({
     tokenKind: "Integer",
     value: 0,
   });
-  expect(numberToken(new Scanner("01")).unwrap()).toMatchObject<Token>({
+  expect(integerToken(new Scanner("01")).unwrap()).toMatchObject<Token>({
     tokenKind: "Integer",
     value: 1,
   });
-  expect(numberToken(new Scanner("20")).unwrap()).toMatchObject<Token>({
+  expect(integerToken(new Scanner("20")).unwrap()).toMatchObject<Token>({
     tokenKind: "Integer",
     value: 20,
   });

--- a/src/syntax/tokenizer.ts
+++ b/src/syntax/tokenizer.ts
@@ -56,12 +56,12 @@ export const keywordToken: (keyword: ReservedWordKind) => Parser<KeywordToken> =
   };
 };
 
-export const numberToken: Parser<IntegerToken> = scanner => {
+export const integerToken: Parser<IntegerToken> = scanner => {
   const hit = scanner.match(/^(\d+)/);
   if (!hit)
     return error({
       confirmed: false,
-      message: "Number expected.",
+      message: "Integer expected.",
       occurence: { loc: { pos: scanner.pos, end: scanner.pos + 1 } },
     });
   return ok({

--- a/src/syntax/tokenizer.ts
+++ b/src/syntax/tokenizer.ts
@@ -4,6 +4,7 @@ import {
   SymbolKind,
   SymbolToken,
   IntegerToken,
+  FloatToken,
   ReservedWords,
   ReservedWordKind,
   KeywordToken,
@@ -67,6 +68,21 @@ export const integerToken: Parser<IntegerToken> = scanner => {
   return ok({
     tokenKind: "Integer",
     value: parseInt(hit[1], 10),
+    loc: scanner.consume(hit[1].length),
+  });
+};
+
+export const decimalToken: Parser<FloatToken> = scanner => {
+  const hit = scanner.match(/^(\d+\.\d*)/);
+  if (!hit)
+    return error({
+      confirmed: false,
+      message: "Floating number expected.",
+      occurence: { loc: { pos: scanner.pos, end: scanner.pos + 1 } },
+    });
+  return ok({
+    tokenKind: "Float",
+    value: parseFloat(hit[1]),
     loc: scanner.consume(hit[1].length),
   });
 };

--- a/src/syntax/tokenizer.ts
+++ b/src/syntax/tokenizer.ts
@@ -4,7 +4,7 @@ import {
   SymbolKind,
   SymbolToken,
   IntegerToken,
-  FloatToken,
+  DecimalToken,
   ReservedWords,
   ReservedWordKind,
   KeywordToken,
@@ -72,7 +72,7 @@ export const integerToken: Parser<IntegerToken> = scanner => {
   });
 };
 
-export const decimalToken: Parser<FloatToken> = scanner => {
+export const decimalToken: Parser<DecimalToken> = scanner => {
   const hit = scanner.match(/^(\d+\.\d*)/);
   if (!hit)
     return error({
@@ -81,7 +81,7 @@ export const decimalToken: Parser<FloatToken> = scanner => {
       occurence: { loc: { pos: scanner.pos, end: scanner.pos + 1 } },
     });
   return ok({
-    tokenKind: "Float",
+    tokenKind: "Decimal",
     value: parseFloat(hit[1]),
     loc: scanner.consume(hit[1].length),
   });

--- a/src/syntax/types.ts
+++ b/src/syntax/types.ts
@@ -11,6 +11,9 @@ export type Symbols = readonly [
   ">",
   "<=",
   ">=",
+  "+.",
+  "-.",
+  "*.",
   "||",
   "&&",
   "==",
@@ -72,6 +75,8 @@ export interface OperationBase<T extends string> {
 
 export interface MinusOperation extends OperationBase<"Minus"> {}
 
+export interface FMinusOperation extends OperationBase<"FMinus"> {}
+
 export interface AddOperation extends OperationBase<"Add"> {}
 
 export interface SubOperation extends OperationBase<"Sub"> {}
@@ -86,6 +91,12 @@ export interface LEOperation extends OperationBase<"LessEqualThan"> {}
 
 export interface GEOperation extends OperationBase<"GreaterEqualThan"> {}
 
+export interface FAddOperation extends OperationBase<"FAdd"> {}
+
+export interface FSubOperation extends OperationBase<"FSub"> {}
+
+export interface FMultiplyOperation extends OperationBase<"FMultiply"> {}
+
 export interface OrOperation extends OperationBase<"Or"> {}
 
 export interface AndOperation extends OperationBase<"And"> {}
@@ -94,7 +105,7 @@ export interface EQOperation extends OperationBase<"Equal"> {}
 
 export interface NEOperation extends OperationBase<"NotEqual"> {}
 
-export type UnaryOperation = MinusOperation;
+export type UnaryOperation = MinusOperation | FMinusOperation;
 export type BinaryOperation =
   | AddOperation
   | SubOperation
@@ -103,6 +114,9 @@ export type BinaryOperation =
   | GTOperation
   | LEOperation
   | GEOperation
+  | FAddOperation
+  | FSubOperation
+  | FMultiplyOperation
   | OrOperation
   | AndOperation
   | EQOperation

--- a/src/syntax/types.ts
+++ b/src/syntax/types.ts
@@ -59,7 +59,11 @@ export interface IntegerToken extends TokenBase<"Integer"> {
   readonly value: number;
 }
 
-export type Token = SymbolToken | KeywordToken | IntegerToken | VariableToken;
+export interface FloatToken extends TokenBase<"Float"> {
+  readonly value: number;
+}
+
+export type Token = SymbolToken | KeywordToken | IntegerToken | FloatToken | VariableToken;
 
 export interface OperationBase<T extends string> {
   readonly kind: T;
@@ -107,6 +111,10 @@ export type BinaryOperation =
 export interface Node<T extends string> extends Tree<T>, Position {}
 
 export interface IntLiteralNode extends Node<"IntLiteral"> {
+  readonly value: number;
+}
+
+export interface FloatLiteralNode extends Node<"FloatLiteral"> {
   readonly value: number;
 }
 
@@ -199,6 +207,7 @@ export interface MatchExpressionNode extends Node<"MatchExpression"> {
 
 export type ExpressionNode =
   | IntLiteralNode
+  | FloatLiteralNode
   | BoolLiteralNode
   | EmptyListNode
   | IdentifierNode

--- a/src/syntax/types.ts
+++ b/src/syntax/types.ts
@@ -83,14 +83,6 @@ export interface SubOperation extends OperationBase<"Sub"> {}
 
 export interface MultiplyOperation extends OperationBase<"Multiply"> {}
 
-export interface LTOperation extends OperationBase<"LessThan"> {}
-
-export interface GTOperation extends OperationBase<"GreaterThan"> {}
-
-export interface LEOperation extends OperationBase<"LessEqualThan"> {}
-
-export interface GEOperation extends OperationBase<"GreaterEqualThan"> {}
-
 export interface FAddOperation extends OperationBase<"FAdd"> {}
 
 export interface FSubOperation extends OperationBase<"FSub"> {}
@@ -101,26 +93,31 @@ export interface OrOperation extends OperationBase<"Or"> {}
 
 export interface AndOperation extends OperationBase<"And"> {}
 
+export interface LTOperation extends OperationBase<"LessThan"> {}
+
+export interface GTOperation extends OperationBase<"GreaterThan"> {}
+
+export interface LEOperation extends OperationBase<"LessEqualThan"> {}
+
+export interface GEOperation extends OperationBase<"GreaterEqualThan"> {}
+
 export interface EQOperation extends OperationBase<"Equal"> {}
 
 export interface NEOperation extends OperationBase<"NotEqual"> {}
+
+export type ComparisonOperations = LTOperation | LEOperation | GTOperation | GEOperation | EQOperation | NEOperation;
 
 export type UnaryOperation = MinusOperation | FMinusOperation;
 export type BinaryOperation =
   | AddOperation
   | SubOperation
   | MultiplyOperation
-  | LTOperation
-  | GTOperation
-  | LEOperation
-  | GEOperation
   | FAddOperation
   | FSubOperation
   | FMultiplyOperation
   | OrOperation
   | AndOperation
-  | EQOperation
-  | NEOperation;
+  | ComparisonOperations;
 
 export interface Node<T extends string> extends Tree<T>, Position {}
 

--- a/src/syntax/types.ts
+++ b/src/syntax/types.ts
@@ -62,11 +62,11 @@ export interface IntegerToken extends TokenBase<"Integer"> {
   readonly value: number;
 }
 
-export interface FloatToken extends TokenBase<"Float"> {
+export interface DecimalToken extends TokenBase<"Decimal"> {
   readonly value: number;
 }
 
-export type Token = SymbolToken | KeywordToken | IntegerToken | FloatToken | VariableToken;
+export type Token = SymbolToken | KeywordToken | IntegerToken | DecimalToken | VariableToken;
 
 export interface OperationBase<T extends string> {
   readonly kind: T;

--- a/src/type-checker/ftv.ts
+++ b/src/type-checker/ftv.ts
@@ -30,6 +30,7 @@ function subtract(sortedA: FTV, sortedB: FTV): FTV {
 function getTypeFTVLoop(type: TypeValue): FTV {
   switch (type.kind) {
     case "Int":
+    case "Float":
     case "Bool":
       return [];
     case "TypeParameter":

--- a/src/type-checker/primary-type.test.ts
+++ b/src/type-checker/primary-type.test.ts
@@ -9,6 +9,9 @@ const fixture: Record<string, () => string> = {
   "0 + 0": () => "int",
   "0 - 0": () => "int",
   "0 * 0": () => "int",
+  "0.0 +. 0.0": () => "float",
+  "0.0 -. 0.0": () => "float",
+  "0.0 *. 0.0": () => "float",
   "0 < 1": () => "bool",
   "0 <= 1": () => "bool",
   "0 > 1": () => "bool",
@@ -52,8 +55,39 @@ describe(getPrimaryType, () => {
   });
 
   test("failure", () => {
+    expect(parse("-.1").mapValue(getPrimaryType).ok).toBeFalsy();
+    expect(parse("-1.").mapValue(getPrimaryType).ok).toBeFalsy();
     expect(parse("1 + false").mapValue(getPrimaryType).ok).toBeFalsy();
+    expect(parse("1 +. 1").mapValue(getPrimaryType).ok).toBeFalsy();
+    expect(parse("1 -. 1").mapValue(getPrimaryType).ok).toBeFalsy();
+    expect(parse("1 *. 1").mapValue(getPrimaryType).ok).toBeFalsy();
+    expect(parse("1. + 1.").mapValue(getPrimaryType).ok).toBeFalsy();
+    expect(parse("1. - 1.").mapValue(getPrimaryType).ok).toBeFalsy();
+    expect(parse("1. * 1.").mapValue(getPrimaryType).ok).toBeFalsy();
+    expect(parse("1 < false").mapValue(getPrimaryType).ok).toBeFalsy();
+    expect(parse("1 < 1.0").mapValue(getPrimaryType).ok).toBeFalsy();
+    expect(parse("1 < []").mapValue(getPrimaryType).ok).toBeFalsy();
+    expect(parse("1 < fun x -> x").mapValue(getPrimaryType).ok).toBeFalsy();
+    expect(parse("1 <= false").mapValue(getPrimaryType).ok).toBeFalsy();
+    expect(parse("1 <= 1.0").mapValue(getPrimaryType).ok).toBeFalsy();
+    expect(parse("1 <= []").mapValue(getPrimaryType).ok).toBeFalsy();
+    expect(parse("1 <= fun x -> x").mapValue(getPrimaryType).ok).toBeFalsy();
+    expect(parse("1 > false").mapValue(getPrimaryType).ok).toBeFalsy();
+    expect(parse("1 > 1.0").mapValue(getPrimaryType).ok).toBeFalsy();
+    expect(parse("1 > []").mapValue(getPrimaryType).ok).toBeFalsy();
+    expect(parse("1 > fun x -> x").mapValue(getPrimaryType).ok).toBeFalsy();
+    expect(parse("1 >= false").mapValue(getPrimaryType).ok).toBeFalsy();
+    expect(parse("1 >= 1.0").mapValue(getPrimaryType).ok).toBeFalsy();
+    expect(parse("1 >= []").mapValue(getPrimaryType).ok).toBeFalsy();
+    expect(parse("1 >= fun x -> x").mapValue(getPrimaryType).ok).toBeFalsy();
     expect(parse("1 == false").mapValue(getPrimaryType).ok).toBeFalsy();
+    expect(parse("1 == 1.0").mapValue(getPrimaryType).ok).toBeFalsy();
+    expect(parse("1 == []").mapValue(getPrimaryType).ok).toBeFalsy();
+    expect(parse("1 == fun x -> x").mapValue(getPrimaryType).ok).toBeFalsy();
+    expect(parse("1 != false").mapValue(getPrimaryType).ok).toBeFalsy();
+    expect(parse("1 != 1.0").mapValue(getPrimaryType).ok).toBeFalsy();
+    expect(parse("1 != []").mapValue(getPrimaryType).ok).toBeFalsy();
+    expect(parse("1 != fun x -> x").mapValue(getPrimaryType).ok).toBeFalsy();
     expect(parse("1 || 1").mapValue(getPrimaryType).ok).toBeFalsy();
     expect(parse("1 && 1").mapValue(getPrimaryType).ok).toBeFalsy();
     expect(parse("true::1::[]").mapValue(getPrimaryType).ok).toBeFalsy();

--- a/src/type-checker/primary-type.test.ts
+++ b/src/type-checker/primary-type.test.ts
@@ -13,6 +13,14 @@ const fixture: Record<string, () => string> = {
   "0 <= 1": () => "bool",
   "0 > 1": () => "bool",
   "0 >= 1": () => "bool",
+  "0.0 < 1.0": () => "bool",
+  "0.0 <= 1.0": () => "bool",
+  "0.0 > 1.0": () => "bool",
+  "0.0 >= 1.0": () => "bool",
+  "true < true": () => "bool",
+  "true <= true": () => "bool",
+  "true > true": () => "bool",
+  "true >=  true": () => "bool",
   "true || false": () => "bool",
   "true && false": () => "bool",
   "true == false": () => "bool",
@@ -46,10 +54,6 @@ describe(getPrimaryType, () => {
   test("failure", () => {
     expect(parse("1 + false").mapValue(getPrimaryType).ok).toBeFalsy();
     expect(parse("1 == false").mapValue(getPrimaryType).ok).toBeFalsy();
-    expect(parse("true < true").mapValue(getPrimaryType).ok).toBeFalsy();
-    expect(parse("true <= true").mapValue(getPrimaryType).ok).toBeFalsy();
-    expect(parse("true > true").mapValue(getPrimaryType).ok).toBeFalsy();
-    expect(parse("true >= true").mapValue(getPrimaryType).ok).toBeFalsy();
     expect(parse("1 || 1").mapValue(getPrimaryType).ok).toBeFalsy();
     expect(parse("1 && 1").mapValue(getPrimaryType).ok).toBeFalsy();
     expect(parse("true::1::[]").mapValue(getPrimaryType).ok).toBeFalsy();

--- a/src/type-checker/primary-type.ts
+++ b/src/type-checker/primary-type.ts
@@ -3,6 +3,7 @@ import { PrimaryTypeResult, PrimaryTypeContext } from "./types";
 import { createRootEnvironment, ParmGenerator } from "./type-environment";
 import { createTreeTraverser } from "../structure/traverser";
 import { intLiteral } from "./pt-node/int-literal";
+import { floatLiteral } from "./pt-node/float-literal";
 import { boolLiteral } from "./pt-node/bool-literal";
 import { emptyList } from "./pt-node/empty-list";
 import { identifier } from "./pt-node/identifier";
@@ -19,6 +20,7 @@ import { functionApplication } from "./pt-node/function-application";
 export function getPrimaryType(expression: ExpressionNode) {
   return createTreeTraverser<ExpressionNode, PrimaryTypeContext, PrimaryTypeResult>({
     intLiteral,
+    floatLiteral,
     boolLiteral,
     emptyList,
     identifier,

--- a/src/type-checker/pt-node/binary-expression.ts
+++ b/src/type-checker/pt-node/binary-expression.ts
@@ -5,10 +5,13 @@ import { result } from "./_result";
 import { unify } from "../unify";
 import { toEquationSet } from "../substitute";
 
-const RESULT_TYPES_BY_OP: Record<BinaryOperation["kind"], "Bool" | "Int"> = {
+const RESULT_TYPES_BY_OP: Record<BinaryOperation["kind"], "Bool" | "Int" | "Float"> = {
   Add: "Int",
+  FAdd: "Float",
   Sub: "Int",
+  FSub: "Float",
   Multiply: "Int",
+  FMultiply: "Float",
   LessThan: "Bool",
   LessEqualThan: "Bool",
   GreaterThan: "Bool",
@@ -24,8 +27,16 @@ function getConstraints(
   left: PrimaryTypeValue,
   right: PrimaryTypeValue,
 ): readonly TypeEquation[] {
-  if (expression.op.kind === "Equal" || expression.op.kind === "NotEqual")
+  if (
+    expression.op.kind === "LessThan" ||
+    expression.op.kind === "LessEqualThan" ||
+    expression.op.kind === "GreaterThan" ||
+    expression.op.kind === "GreaterEqualThan" ||
+    expression.op.kind === "Equal" ||
+    expression.op.kind === "NotEqual"
+  ) {
     return [{ lhs: left.expressionType, rhs: right.expressionType }];
+  }
 
   const expectedNodeType = expression.op.kind === "And" || expression.op.kind === "Or" ? "Bool" : "Int";
 

--- a/src/type-checker/pt-node/binary-expression.ts
+++ b/src/type-checker/pt-node/binary-expression.ts
@@ -38,7 +38,12 @@ function getConstraints(
     return [{ lhs: left.expressionType, rhs: right.expressionType }];
   }
 
-  const expectedNodeType = expression.op.kind === "And" || expression.op.kind === "Or" ? "Bool" : "Int";
+  const expectedNodeType =
+    expression.op.kind === "And" || expression.op.kind === "Or"
+      ? "Bool"
+      : expression.op.kind === "Add" || expression.op.kind === "Sub" || expression.op.kind === "Multiply"
+      ? "Int"
+      : "Float";
 
   return [
     {

--- a/src/type-checker/pt-node/float-literal.ts
+++ b/src/type-checker/pt-node/float-literal.ts
@@ -1,0 +1,4 @@
+import { PrimaryTypeNode } from "../types";
+import { result } from "./_result";
+
+export const floatLiteral: PrimaryTypeNode<"FloatLiteral"> = node => result.ok({ kind: "Float", referencedFrom: node });

--- a/src/type-checker/pt-node/unary-expression.ts
+++ b/src/type-checker/pt-node/unary-expression.ts
@@ -20,7 +20,23 @@ export const unaryExpression: PrimaryTypeNode<"UnaryExpression"> = (expression, 
           ),
         ),
       );
+    case "FMinus":
+      return next(expression.exp, ctx).mapValue(exp =>
+        unify([
+          ...toEquationSet(exp),
+          { lhs: exp.expressionType, rhs: { kind: "Float", referencedFrom: expression } },
+        ]).mapValue(unified =>
+          result.ok(
+            {
+              kind: "Int",
+              referencedFrom: expression,
+            },
+            unified,
+          ),
+        ),
+      );
     default:
+      // @ts-expect-error
       throw new Error(`invalid operation ${expression.op.kind}`);
   }
 };

--- a/src/type-checker/substitute.ts
+++ b/src/type-checker/substitute.ts
@@ -3,6 +3,7 @@ import { TypeEquation, TypeSubstitution, TypeValue, TypeScheme, TypeEnvironment 
 function substituteTypeInner(type: TypeValue, substitution: TypeSubstitution): TypeValue {
   switch (type.kind) {
     case "Int":
+    case "Float":
     case "Bool":
       return type;
     case "TypeParameter":

--- a/src/type-checker/testing/helpers.ts
+++ b/src/type-checker/testing/helpers.ts
@@ -1,5 +1,6 @@
 import {
   IntType,
+  FloatType,
   BoolType,
   TypeParameterType,
   TypeValue,
@@ -14,6 +15,11 @@ const referencedFrom = {};
 
 export const int = (): IntType => ({
   kind: "Int",
+  referencedFrom,
+});
+
+export const float = (): FloatType => ({
+  kind: "Float",
   referencedFrom,
 });
 

--- a/src/type-checker/types.ts
+++ b/src/type-checker/types.ts
@@ -9,6 +9,8 @@ export interface TypeValueBase<T> {
 
 export interface IntType extends TypeValueBase<"Int"> {}
 
+export interface FloatType extends TypeValueBase<"Float"> {}
+
 export interface BoolType extends TypeValueBase<"Bool"> {}
 
 export interface TypeParameterType extends TypeValueBase<"TypeParameter"> {
@@ -24,7 +26,7 @@ export interface FunctionType extends TypeValueBase<"Function"> {
   readonly returnType: TypeValue;
 }
 
-export type TypeValue = IntType | BoolType | TypeParameterType | ListType | FunctionType;
+export type TypeValue = IntType | FloatType | BoolType | TypeParameterType | ListType | FunctionType;
 
 export interface TypeScheme {
   readonly kind: "TypeScheme";

--- a/src/type-checker/unparse.test.ts
+++ b/src/type-checker/unparse.test.ts
@@ -1,12 +1,13 @@
 import { createTypePrinter } from "./unparse";
 import { TypeValue } from "./types";
-import { int, list, param, func, bool } from "./testing/helpers";
+import { int, float, list, param, func, bool } from "./testing/helpers";
 
 describe(createTypePrinter, () => {
   describe("without option", () => {
     const print = (type: TypeValue) => createTypePrinter()(type);
     test("unparse", () => {
       expect(print(int())).toBe("int");
+      expect(print(float())).toBe("float");
       expect(print(param(0))).toBe("'a");
       expect(print(func(param(0), param(25)))).toBe("'a -> 'z");
       expect(print(func(param(0), param(26)))).toBe("'a -> 'aa");

--- a/src/type-checker/unparse.ts
+++ b/src/type-checker/unparse.ts
@@ -6,6 +6,7 @@ const priorityMap: {
 } = {
   Bool: 0,
   Int: 0,
+  Float: 0,
   TypeParameter: 0,
   List: 10,
   Function: 20,
@@ -47,6 +48,8 @@ function printType(type: TypeValue, ctx: Context): string {
   switch (type.kind) {
     case "Int":
       return "int";
+    case "Float":
+      return "float";
     case "Bool":
       return "bool";
     case "TypeParameter":
@@ -61,6 +64,7 @@ function printType(type: TypeValue, ctx: Context): string {
 function minId(type: TypeValue, current: number = Number.MAX_SAFE_INTEGER): number {
   switch (type.kind) {
     case "Int":
+    case "Float":
     case "Bool":
       return current;
     case "TypeParameter":

--- a/src/type-checker/utils.test.ts
+++ b/src/type-checker/utils.test.ts
@@ -1,12 +1,14 @@
 import { parseMatchPattern } from "../syntax";
 import { equal, getTypeEnvForPattern } from "./utils";
-import { int, bool, func, param, list } from "./testing/helpers";
+import { int, float, bool, func, param, list } from "./testing/helpers";
 import { createRootEnvironment, ParmGenerator } from "./type-environment";
 import { TypeScheme, TypeValue, TypeEquation } from "./types";
 
 describe(equal, () => {
   test(equal.name, () => {
     expect(equal(int(), int())).toBeTruthy();
+    expect(equal(float(), float())).toBeTruthy();
+    expect(equal(float(), int())).toBeFalsy();
     expect(equal(bool(), int())).toBeFalsy();
     expect(equal(int(), bool())).toBeFalsy();
     expect(equal(func(int(), int()), func(int(), int()))).toBeTruthy();

--- a/src/type-checker/utils.ts
+++ b/src/type-checker/utils.ts
@@ -7,6 +7,7 @@ import { MatchExpressionNode, PatternMatchClauseNode, MatchClauseNode } from "..
 export function equal(a: TypeValue, b: TypeValue): boolean {
   switch (a.kind) {
     case "Int":
+    case "Float":
     case "Bool":
       return a.kind === b.kind;
     case "Function": {

--- a/src/wasm/ast-factory.ts
+++ b/src/wasm/ast-factory.ts
@@ -14,8 +14,6 @@ import {
   TypeNode,
   FuncSigNode,
   IndexNode,
-  NumericInstructionNode,
-  VariableInstructionNode,
   LocalVarNode,
   InstructionNode,
   FuncNode,
@@ -41,9 +39,11 @@ import {
   GlobalTypeNode,
   GlobalNode,
   ExportedGlobalNode,
+  Int32NumericInstructionNode,
+  VariableInstructionNode,
 } from "./ast-types";
 import {
-  NumericInstructionKind,
+  Int32NumericInstructionKind,
   VariableInstructionKind,
   ControlInstructionKind,
   MemoryInstructionKind,
@@ -241,13 +241,13 @@ export function variableInstr(
   };
 }
 
-export function numericInstr(
-  instructionKind: NumericInstructionKind,
+export function int32NumericInstr(
+  instructionKind: Int32NumericInstructionKind,
   params?: readonly Int32LiteralNode[],
   pos?: Position,
-): NumericInstructionNode {
+): Int32NumericInstructionNode {
   return {
-    kind: "NumericInstruction",
+    kind: "Int32NumericInstruction",
     instructionKind,
     parameters: params ?? [],
     loc: pos?.loc,

--- a/src/wasm/ast-factory.ts
+++ b/src/wasm/ast-factory.ts
@@ -4,6 +4,9 @@ import {
   ModuleNode,
   Uint32LiteralNode,
   Int32LiteralNode,
+  Int64LiteralNode,
+  Float32LiteralNode,
+  Float64LiteralNode,
   LimitsNode,
   MemoryNode,
   IdentifierNode,
@@ -25,6 +28,11 @@ import {
   ControlInstructionNode,
   IfInstructionNode,
   MemoryInstructionNode,
+  VariableInstructionNode,
+  Int32NumericInstructionNode,
+  Int64NumericInstructionNode,
+  Float32NumericInstructionNode,
+  Float64NumericInstructionNode,
   FuncTypeRefNode,
   ExportedTableNode,
   RefKind,
@@ -39,11 +47,12 @@ import {
   GlobalTypeNode,
   GlobalNode,
   ExportedGlobalNode,
-  Int32NumericInstructionNode,
-  VariableInstructionNode,
 } from "./ast-types";
 import {
   Int32NumericInstructionKind,
+  Int64NumericInstructionKind,
+  Float32NumericInstructionKind,
+  Float64NumericInstructionKind,
   VariableInstructionKind,
   ControlInstructionKind,
   MemoryInstructionKind,
@@ -60,6 +69,30 @@ export function uint32(value: number, pos?: Position): Uint32LiteralNode {
 export function int32(value: number, pos?: Position): Int32LiteralNode {
   return {
     kind: "Int32Literal",
+    value,
+    loc: pos?.loc,
+  };
+}
+
+export function int64(value: number, pos?: Position): Int64LiteralNode {
+  return {
+    kind: "Int64Literal",
+    value,
+    loc: pos?.loc,
+  };
+}
+
+export function float32(value: number, pos?: Position): Float32LiteralNode {
+  return {
+    kind: "Float32Literal",
+    value,
+    loc: pos?.loc,
+  };
+}
+
+export function float64(value: number, pos?: Position): Float64LiteralNode {
+  return {
+    kind: "Float64Literal",
     value,
     loc: pos?.loc,
   };
@@ -248,6 +281,45 @@ export function int32NumericInstr(
 ): Int32NumericInstructionNode {
   return {
     kind: "Int32NumericInstruction",
+    instructionKind,
+    parameters: params ?? [],
+    loc: pos?.loc,
+  };
+}
+
+export function int64NumericInstr(
+  instructionKind: Int64NumericInstructionKind,
+  params?: readonly Int64LiteralNode[],
+  pos?: Position,
+): Int64NumericInstructionNode {
+  return {
+    kind: "Int64NumericInstruction",
+    instructionKind,
+    parameters: params ?? [],
+    loc: pos?.loc,
+  };
+}
+
+export function float32NumericInstr(
+  instructionKind: Float32NumericInstructionKind,
+  params?: readonly Float32LiteralNode[],
+  pos?: Position,
+): Float32NumericInstructionNode {
+  return {
+    kind: "Float32NumericInstruction",
+    instructionKind,
+    parameters: params ?? [],
+    loc: pos?.loc,
+  };
+}
+
+export function float64NumericInstr(
+  instructionKind: Float64NumericInstructionKind,
+  params?: readonly Float64LiteralNode[],
+  pos?: Position,
+): Float64NumericInstructionNode {
+  return {
+    kind: "Float64NumericInstruction",
     instructionKind,
     parameters: params ?? [],
     loc: pos?.loc,

--- a/src/wasm/ast-types.ts
+++ b/src/wasm/ast-types.ts
@@ -15,7 +15,7 @@ interface Node<T extends string> extends Tree<T>, Position {}
 export type Symbols = ["(", ")"];
 export type SymbolKind = Symbols[number];
 
-export type ValueTypes = ["i32"];
+export type ValueTypes = ["i32", "i64", "f32", "f64"];
 export type ValueTypeKind = ValueTypes[number];
 
 export type ReservedWords = [

--- a/src/wasm/ast-types.ts
+++ b/src/wasm/ast-types.ts
@@ -3,6 +3,9 @@ import { Position } from "../parser-util";
 import {
   ControlInstructionKind,
   Int32NumericInstructionKind,
+  Int64NumericInstructionKind,
+  Float32NumericInstructionKind,
+  Float64NumericInstructionKind,
   VariableInstructionKind,
   MemoryInstructionKind,
 } from "./instructions-map";
@@ -49,6 +52,9 @@ export type ReservedWordKind =
   | ControlInstructionKind
   | VariableInstructionKind
   | Int32NumericInstructionKind
+  | Int64NumericInstructionKind
+  | Float32NumericInstructionKind
+  | Float64NumericInstructionKind
   | MemoryInstructionKind;
 
 export interface TokenBase<T extends string> extends Position {
@@ -67,6 +73,10 @@ export interface IntToken extends TokenBase<"Int"> {
   readonly value: number;
 }
 
+export interface DecimalToken extends TokenBase<"Decimal"> {
+  readonly value: number;
+}
+
 export interface StringToken extends TokenBase<"String"> {
   readonly value: string;
 }
@@ -75,13 +85,19 @@ export interface IdentifierToken extends TokenBase<"Identifier"> {
   readonly name: string;
 }
 
-interface NumberLiteral {
+export interface NumberLiteral {
   readonly value: number;
 }
 
 export interface Uint32LiteralNode extends NumberLiteral, Node<"Uint32Literal"> {}
 
 export interface Int32LiteralNode extends NumberLiteral, Node<"Int32Literal"> {}
+
+export interface Int64LiteralNode extends NumberLiteral, Node<"Int64Literal"> {}
+
+export interface Float32LiteralNode extends NumberLiteral, Node<"Float32Literal"> {}
+
+export interface Float64LiteralNode extends NumberLiteral, Node<"Float64Literal"> {}
 
 export interface IdentifierNode extends Node<"Identifier"> {
   readonly value: string;
@@ -151,13 +167,32 @@ export interface Int32NumericInstructionNode extends Node<"Int32NumericInstructi
   readonly parameters: readonly Int32LiteralNode[];
 }
 
-export type NumericInstructionNode = Int32NumericInstructionNode;
+export interface Int64NumericInstructionNode extends Node<"Int64NumericInstruction"> {
+  readonly instructionKind: Int64NumericInstructionKind;
+  readonly parameters: readonly Int64LiteralNode[];
+}
+
+export interface Float32NumericInstructionNode extends Node<"Float32NumericInstruction"> {
+  readonly instructionKind: Float32NumericInstructionKind;
+  readonly parameters: readonly Float32LiteralNode[];
+}
+
+export interface Float64NumericInstructionNode extends Node<"Float64NumericInstruction"> {
+  readonly instructionKind: Float64NumericInstructionKind;
+  readonly parameters: readonly Float64LiteralNode[];
+}
 
 export interface MemoryInstructionNode extends Node<"MemoryInstruction"> {
   readonly instructionKind: MemoryInstructionKind;
   readonly offset: Uint32LiteralNode | null;
   readonly align: Uint32LiteralNode | null;
 }
+
+export type NumericInstructionNode =
+  | Int32NumericInstructionNode
+  | Int64NumericInstructionNode
+  | Float32NumericInstructionNode
+  | Float64NumericInstructionNode;
 
 export type StructuredControleInstructionNode = IfInstructionNode;
 export type PlainInstructionNode =

--- a/src/wasm/ast-types.ts
+++ b/src/wasm/ast-types.ts
@@ -2,7 +2,7 @@ import { Tree } from "../structure";
 import { Position } from "../parser-util";
 import {
   ControlInstructionKind,
-  NumericInstructionKind,
+  Int32NumericInstructionKind,
   VariableInstructionKind,
   MemoryInstructionKind,
 } from "./instructions-map";
@@ -31,6 +31,9 @@ export type ReservedWords = [
   "result",
   "local",
   "i32",
+  "i64",
+  "f32",
+  "f64",
   "if",
   "else",
   "end",
@@ -45,7 +48,7 @@ export type ReservedWordKind =
   | ReservedWords[number]
   | ControlInstructionKind
   | VariableInstructionKind
-  | NumericInstructionKind
+  | Int32NumericInstructionKind
   | MemoryInstructionKind;
 
 export interface TokenBase<T extends string> extends Position {
@@ -143,10 +146,12 @@ export interface VariableInstructionNode extends Node<"VariableInstruction"> {
   readonly parameters: readonly IndexNode[];
 }
 
-export interface NumericInstructionNode extends Node<"NumericInstruction"> {
-  readonly instructionKind: NumericInstructionKind;
+export interface Int32NumericInstructionNode extends Node<"Int32NumericInstruction"> {
+  readonly instructionKind: Int32NumericInstructionKind;
   readonly parameters: readonly Int32LiteralNode[];
 }
+
+export type NumericInstructionNode = Int32NumericInstructionNode;
 
 export interface MemoryInstructionNode extends Node<"MemoryInstruction"> {
   readonly instructionKind: MemoryInstructionKind;

--- a/src/wasm/binary/unparser.test.ts
+++ b/src/wasm/binary/unparser.test.ts
@@ -85,15 +85,10 @@ describe(unparse, () => {
     test("Float32 function example", async () => {
       const source = `
         (module
-          (func $add (param $a f32) (param $b f32) (result f32)
-            local.get $a
-            local.get $b
-            f32.add
-          )
           (func $twice (param $x f32) (result f32)
+            f32.const 2.0
             local.get $x
-            local.get $x
-            call $add
+            f32.mul
           )
           (export "main" (func $twice))
         )
@@ -106,15 +101,10 @@ describe(unparse, () => {
     test("Float64 function example", async () => {
       const source = `
         (module
-          (func $add (param $a f64) (param $b f64) (result f64)
-            local.get $a
-            local.get $b
-            f64.add
-          )
           (func $twice (param $x f64) (result f64)
+            f64.const 2.0
             local.get $x
-            local.get $x
-            call $add
+            f64.mul
           )
           (export "main" (func $twice))
         )

--- a/src/wasm/binary/unparser.test.ts
+++ b/src/wasm/binary/unparser.test.ts
@@ -7,22 +7,6 @@ const unparse = (mod: Module) => baseUnparse(mod, { enableNameSection: false });
 
 describe(unparse, () => {
   describe("unparse result should work as WebAssembly buffered source", () => {
-    test("Add function example", async () => {
-      const source = `
-        (module
-          (func $add (param $a i32) (param $b i32) (result i32)
-            local.get $a
-            local.get $b
-            i32.add
-          )
-          (export "main" (func $add))
-        )
-      `;
-      const buf = parse(source).mapValue(convertModule).map(unparse).unwrap();
-      const { instance } = await WebAssembly.instantiate(buf, {});
-      expect((instance.exports["main"] as Function)(1, 2)).toBe(3);
-    });
-
     test("Local variable  example", async () => {
       const source = `
         (module
@@ -62,7 +46,7 @@ describe(unparse, () => {
       expect((instance.exports["main"] as Function)(0)).toBe(1);
     });
 
-    test("Add function example", async () => {
+    test("Int32 function example", async () => {
       const source = `
         (module
           (func $add (param $a i32) (param $b i32) (result i32)
@@ -81,6 +65,63 @@ describe(unparse, () => {
       const buf = parse(source).mapValue(convertModule).map(unparse).unwrap();
       const { instance } = await WebAssembly.instantiate(buf, {});
       expect((instance.exports["main"] as Function)(2)).toBe(4);
+    });
+
+    // Node v14 can't compile this case
+    test.skip("Int64 function example", async () => {
+      const source = `
+        (module
+          (func $twice (result i64)
+            i64.const 1
+          )
+          (export "main" (func $twice))
+        )
+      `;
+      const buf = parse(source).mapValue(convertModule).map(unparse).unwrap();
+      const { instance } = await WebAssembly.instantiate(buf, {});
+      expect((instance.exports["main"] as Function)(2)).toBe(4);
+    });
+
+    test("Float32 function example", async () => {
+      const source = `
+        (module
+          (func $add (param $a f32) (param $b f32) (result f32)
+            local.get $a
+            local.get $b
+            f32.add
+          )
+          (func $twice (param $x f32) (result f32)
+            local.get $x
+            local.get $x
+            call $add
+          )
+          (export "main" (func $twice))
+        )
+      `;
+      const buf = parse(source).mapValue(convertModule).map(unparse).unwrap();
+      const { instance } = await WebAssembly.instantiate(buf, {});
+      expect((instance.exports["main"] as Function)(2.0)).toBe(4.0);
+    });
+
+    test("Float64 function example", async () => {
+      const source = `
+        (module
+          (func $add (param $a f64) (param $b f64) (result f64)
+            local.get $a
+            local.get $b
+            f64.add
+          )
+          (func $twice (param $x f64) (result f64)
+            local.get $x
+            local.get $x
+            call $add
+          )
+          (export "main" (func $twice))
+        )
+      `;
+      const buf = parse(source).mapValue(convertModule).map(unparse).unwrap();
+      const { instance } = await WebAssembly.instantiate(buf, {});
+      expect((instance.exports["main"] as Function)(2.0)).toBe(4.0);
     });
 
     test("Memory instruction example", async () => {

--- a/src/wasm/binary/unparser.ts
+++ b/src/wasm/binary/unparser.ts
@@ -22,7 +22,7 @@ import { BinaryOutputOptions } from "../types";
 
 import {
   variableInstructions,
-  numericInstructions,
+  i32NumberInstructions,
   controlInstructions,
   structuredInstructions,
   memoryInstructions,
@@ -133,7 +133,7 @@ function instructions(instrs: readonly Instruction[]): readonly Uint8Array[] {
       const { code } = variableInstructions[instr.instructionKind];
       return concat(byteMark(code), ...instr.parameters.map(idx => uint32(idx)));
     } else if (instr.kind === "NumericInstruction") {
-      const { code, args } = numericInstructions[instr.instructionKind];
+      const { code, args } = i32NumberInstructions[instr.instructionKind];
       return concat(
         byteMark(code),
         ...instr.parameters.map((p, argIdx) => {

--- a/src/wasm/binary/unparser.ts
+++ b/src/wasm/binary/unparser.ts
@@ -57,11 +57,11 @@ function int64(value: number) {
 }
 
 function float32(value: number) {
-  return new Uint8Array(new Float32Array(value).buffer);
+  return new Uint8Array(new Float32Array([value]).buffer);
 }
 
 function float64(value: number) {
-  return new Uint8Array(new Float64Array(value).buffer);
+  return new Uint8Array(new Float64Array([value]).buffer);
 }
 
 function str(value: string) {

--- a/src/wasm/binary/unparser.ts
+++ b/src/wasm/binary/unparser.ts
@@ -106,8 +106,20 @@ function indirectMap(nmap: readonly IndirectNameMap[]): readonly Uint8Array[] {
   return nmap.map(({ idx, nameMap: subMap }) => concat(uint32(idx), vec(nameMap(subMap))));
 }
 
-function numType(_valueType: ValType): Uint8Array {
-  return byteMark(0x7f); // for i32
+function numType(valType: ValType): Uint8Array {
+  switch (valType.kind) {
+    case "Int32Type":
+      return byteMark(0x7f);
+    case "Int64Type":
+      return byteMark(0x7e);
+    case "Float32Type":
+      return byteMark(0x7d);
+    case "Float64Type":
+      return byteMark(0x7c);
+    default:
+      // @ts-expect-error
+      throw new Error(`Invalid value type kind: ${valType.kind}`);
+  }
 }
 
 function funcType(ft: FuncType): Uint8Array {

--- a/src/wasm/converter/convert-node/func.ts
+++ b/src/wasm/converter/convert-node/func.ts
@@ -4,7 +4,7 @@ import { Func, FuncType, Instruction, ValType, UInt32Index, ResultType } from ".
 import { RefereneceContext, findIndex, createIndex } from "../ref";
 import {
   variableInstructions,
-  numericInstructions,
+  i32NumberInstructions,
   controlInstructions,
   memoryInstructions,
 } from "../../instructions-map";
@@ -82,8 +82,8 @@ const variableInstruction: ConvertInstrFn<"VariableInstruction"> = (node, { refC
   );
 };
 
-const numericInstruction: ConvertInstrFn<"NumericInstruction"> = node => {
-  const { args } = numericInstructions[node.instructionKind];
+const numericInstruction: ConvertInstrFn<"Int32NumericInstruction"> = node => {
+  const { args } = i32NumberInstructions[node.instructionKind];
   return all(
     node.parameters.map((p, i) => {
       if (!args[i]) return error({ message: `${node.instructionKind} can not have ${i}th param` }) as Result<number>;
@@ -154,8 +154,8 @@ export const convertInstr = createTreeTraverser<InstructionNode, ConvertInstrCon
   ifInstruction,
   controlInstruction,
   variableInstruction,
-  numericInstruction,
   memoryInstruction,
+  int32NumericInstruction: numericInstruction,
 });
 
 export function convertFunc(node: FuncNode, idx: number, prev: State, refCtx: RefereneceContext): Result<State> {

--- a/src/wasm/converter/convert-node/func.ts
+++ b/src/wasm/converter/convert-node/func.ts
@@ -3,8 +3,8 @@ import { FuncNode, InstructionNode } from "../../ast-types";
 import { Func, FuncType, Instruction, ValType, UInt32Index, ResultType } from "../../structure-types";
 import { RefereneceContext, findIndex, createIndex } from "../ref";
 import {
+  numberInstructions,
   variableInstructions,
-  i32NumberInstructions,
   controlInstructions,
   memoryInstructions,
 } from "../../instructions-map";
@@ -82,8 +82,10 @@ const variableInstruction: ConvertInstrFn<"VariableInstruction"> = (node, { refC
   );
 };
 
-const numericInstruction: ConvertInstrFn<"Int32NumericInstruction"> = node => {
-  const { args } = i32NumberInstructions[node.instructionKind];
+const numericInstruction: ConvertInstrFn<
+  "Int32NumericInstruction" | "Int64NumericInstruction" | "Float32NumericInstruction" | "Float64NumericInstruction"
+> = node => {
+  const { args } = numberInstructions[node.instructionKind];
   return all(
     node.parameters.map((p, i) => {
       if (!args[i]) return error({ message: `${node.instructionKind} can not have ${i}th param` }) as Result<number>;
@@ -156,6 +158,9 @@ export const convertInstr = createTreeTraverser<InstructionNode, ConvertInstrCon
   variableInstruction,
   memoryInstruction,
   int32NumericInstruction: numericInstruction,
+  int64NumericInstruction: numericInstruction,
+  float32NumericInstruction: numericInstruction,
+  float64NumericInstruction: numericInstruction,
 });
 
 export function convertFunc(node: FuncNode, idx: number, prev: State, refCtx: RefereneceContext): Result<State> {

--- a/src/wasm/converter/convert-node/global.ts
+++ b/src/wasm/converter/convert-node/global.ts
@@ -3,6 +3,7 @@ import { GlobalNode } from "../../ast-types";
 import { Global } from "../../structure-types";
 import { RefereneceContext } from "../ref";
 import { convertInstr } from "./func";
+import { toValType } from "./val-type";
 
 export function convertGlobalNode(node: GlobalNode, refCtx: RefereneceContext): Result<Global> {
   return all(node.expr.map(instr => convertInstr(instr, { refCtx, types: [] }))).map(expr => ({
@@ -11,7 +12,7 @@ export function convertGlobalNode(node: GlobalNode, refCtx: RefereneceContext): 
     type: {
       kind: "GlobalType",
       mutKind: node.type.kind === "MutValueType" ? "Var" : "Const",
-      valueType: { kind: "Int32Type" },
+      valueType: node.type.kind === "ValueType" ? toValType(node.type) : toValType(node.type.valueType),
     },
   }));
 }

--- a/src/wasm/converter/convert-node/typedef.ts
+++ b/src/wasm/converter/convert-node/typedef.ts
@@ -1,11 +1,12 @@
 import { Result, ok } from "../../../structure";
 import { TypeNode } from "../../ast-types";
 import { FuncType } from "../../structure-types";
+import { mapToValTypeListFrom, toValType } from "./val-type";
 
 export function convertType(typedef: TypeNode): Result<FuncType> {
   return ok<FuncType>({
     kind: "FuncType",
-    paramType: typedef.funcType.params.map(() => ({ kind: "Int32Type" })),
-    resultType: typedef.funcType.results.map(() => ({ kind: "Int32Type" })),
+    paramType: mapToValTypeListFrom(typedef.funcType.params),
+    resultType: typedef.funcType.results.map(toValType),
   });
 }

--- a/src/wasm/converter/convert-node/val-type.ts
+++ b/src/wasm/converter/convert-node/val-type.ts
@@ -1,0 +1,36 @@
+import { ok, Result } from "../../../structure";
+import { ValType } from "../../structure-types";
+import { ValueTypeNode } from "../../ast-types";
+
+export function toValType(node: ValueTypeNode): ValType {
+  switch (node.valueKind) {
+    case "i32":
+      return {
+        kind: "Int32Type",
+      };
+    case "i64":
+      return {
+        kind: "Int64Type",
+      };
+    case "f32":
+      return {
+        kind: "Float32Type",
+      };
+    case "f64":
+      return {
+        kind: "Float64Type",
+      };
+    default:
+      throw new Error(`Invalid value kind: ${node.valueKind}`);
+  }
+}
+
+type ValueTypeHolderArray = readonly { readonly valueType: ValueTypeNode }[];
+
+export function convertValueType(node: ValueTypeNode): Result<ValType> {
+  return ok(toValType(node));
+}
+
+export function mapToValTypeListFrom(list: ValueTypeHolderArray) {
+  return list.map(item => toValType(item.valueType));
+}

--- a/src/wasm/instructions-map.ts
+++ b/src/wasm/instructions-map.ts
@@ -24,7 +24,7 @@ export const variableInstructions = {
   "global.set": { code: 0x24, args: ["globals"] },
 } as const;
 
-export const numericInstructions = {
+export const i32NumberInstructions = {
   "i32.const": { code: 0x41, args: ["SignedInteger"] },
 
   "i32.eqz": { code: 0x45, args: [] },
@@ -74,14 +74,16 @@ export type ControlInstructionParamKind = typeof controlInstructions[ControlInst
 export type VariableInstructionKind = keyof typeof variableInstructions;
 export type VariableInstructionParamKind = typeof variableInstructions[VariableInstructionKind]["args"][number];
 
-export type NumericInstructionKind = keyof typeof numericInstructions;
-export type NumericInstructionParamKind = typeof numericInstructions[NumericInstructionKind]["args"][number];
+export type Int32NumericInstructionKind = keyof typeof i32NumberInstructions;
+export type Int32NumericInstructionParamKind =
+  typeof i32NumberInstructions[Int32NumericInstructionKind]["args"][number];
 
 export type MemoryInstructionKind = keyof typeof memoryInstructions;
 
 export const getControlInstructionKinds = () => Object.keys(controlInstructions) as readonly ControlInstructionKind[];
 export const getVariableInstructionKinds = () =>
   Object.keys(variableInstructions) as readonly VariableInstructionKind[];
-export const getNumericInstructionKinds = () => Object.keys(numericInstructions) as readonly NumericInstructionKind[];
+export const getInt32NumericInstructionKinds = () =>
+  Object.keys(i32NumberInstructions) as readonly Int32NumericInstructionKind[];
 
 export const getMemoryInstructionKinds = () => Object.keys(memoryInstructions) as readonly MemoryInstructionKind[];

--- a/src/wasm/instructions-map.ts
+++ b/src/wasm/instructions-map.ts
@@ -59,6 +59,93 @@ export const i32NumberInstructions = {
   "i32.rotr": { code: 0x78, args: [] },
 } as const;
 
+export const i64NumberInstructions = {
+  "i64.const": { code: 0x42, args: ["DoubleSignedInteger"] },
+
+  "i64.eqz": { code: 0x50, args: [] },
+  "i64.eq": { code: 0x51, args: [] },
+  "i64.ne": { code: 0x52, args: [] },
+  "i64.lt_s": { code: 0x53, args: [] },
+  "i64.lt_u": { code: 0x54, args: [] },
+  "i64.gt_s": { code: 0x55, args: [] },
+  "i64.gt_u": { code: 0x56, args: [] },
+  "i64.le_s": { code: 0x57, args: [] },
+  "i64.le_u": { code: 0x58, args: [] },
+  "i64.ge_s": { code: 0x59, args: [] },
+  "i64.ge_u": { code: 0x5a, args: [] },
+
+  "i64.clz": { code: 0x79, args: [] },
+  "i64.ctz": { code: 0x7a, args: [] },
+  "i64.popcnt": { code: 0x7b, args: [] },
+  "i64.add": { code: 0x7c, args: [] },
+  "i64.sub": { code: 0x7d, args: [] },
+  "i64.mul": { code: 0x7e, args: [] },
+  "i64.div_s": { code: 0x7f, args: [] },
+  "i64.div_u": { code: 0x80, args: [] },
+  "i64.rem_s": { code: 0x81, args: [] },
+  "i64.rem_u": { code: 0x82, args: [] },
+  "i64.and": { code: 0x83, args: [] },
+  "i64.or": { code: 0x84, args: [] },
+  "i64.xor": { code: 0x85, args: [] },
+  "i64.shl": { code: 0x86, args: [] },
+  "i64.shr_s": { code: 0x87, args: [] },
+  "i64.shr_u": { code: 0x88, args: [] },
+  "i64.rotl": { code: 0x89, args: [] },
+  "i64.rotr": { code: 0x8a, args: [] },
+} as const;
+
+export const f32NumberInstructions = {
+  "f32.const": { code: 0x43, args: ["SignedFloat"] },
+
+  "f32.eq": { code: 0x5b, args: [] },
+  "f32.ne": { code: 0x5c, args: [] },
+  "f32.lt": { code: 0x5d, args: [] },
+  "f32.gt": { code: 0x5e, args: [] },
+  "f32.le": { code: 0x5f, args: [] },
+  "f32.ge": { code: 0x60, args: [] },
+
+  "f32.abs": { code: 0x8b, args: [] },
+  "f32.neg": { code: 0x8c, args: [] },
+  "f32.ceil": { code: 0x8e, args: [] },
+  "f32.floor": { code: 0x8d, args: [] },
+  "f32.trunc": { code: 0x8f, args: [] },
+  "f32.nearest": { code: 0x90, args: [] },
+  "f32.sqrt": { code: 0x91, args: [] },
+  "f32.add": { code: 0x92, args: [] },
+  "f32.sub": { code: 0x93, args: [] },
+  "f32.mul": { code: 0x94, args: [] },
+  "f32.div": { code: 0x95, args: [] },
+  "f32.min": { code: 0x96, args: [] },
+  "f32.max": { code: 0x97, args: [] },
+  "f32.copysign": { code: 0x98, args: [] },
+} as const;
+
+export const f64NumberInstructions = {
+  "f64.const": { code: 0x44, args: ["DoubleSignedFloat"] },
+
+  "f64.eq": { code: 0x61, args: [] },
+  "f64.ne": { code: 0x62, args: [] },
+  "f64.lt": { code: 0x63, args: [] },
+  "f64.gt": { code: 0x64, args: [] },
+  "f64.le": { code: 0x65, args: [] },
+  "f64.ge": { code: 0x66, args: [] },
+
+  "f64.abs": { code: 0x99, args: [] },
+  "f64.neg": { code: 0x9a, args: [] },
+  "f64.ceil": { code: 0x9b, args: [] },
+  "f64.floor": { code: 0x9c, args: [] },
+  "f64.trunc": { code: 0x9d, args: [] },
+  "f64.nearest": { code: 0x9e, args: [] },
+  "f64.sqrt": { code: 0x9f, args: [] },
+  "f64.add": { code: 0xa0, args: [] },
+  "f64.sub": { code: 0xa1, args: [] },
+  "f64.mul": { code: 0xa2, args: [] },
+  "f64.div": { code: 0xa3, args: [] },
+  "f64.min": { code: 0xa4, args: [] },
+  "f64.max": { code: 0xa5, args: [] },
+  "f64.copysign": { code: 0xa6, args: [] },
+} as const;
+
 export const memoryInstructions = {
   "i32.load": { code: 0x28, defaultAlign: 2 },
   "i32.load8_s": { code: 0x2c, defaultAlign: 0 },
@@ -66,6 +153,13 @@ export const memoryInstructions = {
   "i32.store": { code: 0x36, defaultAlign: 2 },
   "i32.store8": { code: 0x3a, defaultAlign: 0 },
   "i32.store16": { code: 0x3b, defaultAlign: 0 },
+} as const;
+
+export const numberInstructions = {
+  ...i32NumberInstructions,
+  ...i64NumberInstructions,
+  ...f32NumberInstructions,
+  ...f64NumberInstructions,
 } as const;
 
 export type ControlInstructionKind = keyof typeof controlInstructions;
@@ -78,12 +172,41 @@ export type Int32NumericInstructionKind = keyof typeof i32NumberInstructions;
 export type Int32NumericInstructionParamKind =
   typeof i32NumberInstructions[Int32NumericInstructionKind]["args"][number];
 
+export type Int64NumericInstructionKind = keyof typeof i64NumberInstructions;
+export type Int64NumericInstructionParamKind =
+  typeof i64NumberInstructions[Int64NumericInstructionKind]["args"][number];
+
+export type Float32NumericInstructionKind = keyof typeof f32NumberInstructions;
+export type Float32NumericInstructionParamKind =
+  typeof f32NumberInstructions[Float32NumericInstructionKind]["args"][number];
+
+export type Float64NumericInstructionKind = keyof typeof f64NumberInstructions;
+export type Float64NumericInstructionParamKind =
+  typeof f64NumberInstructions[Float64NumericInstructionKind]["args"][number];
+
+export type NumericInstructionKind =
+  | Int32NumericInstructionKind
+  | Int64NumericInstructionKind
+  | Float32NumericInstructionKind
+  | Float64NumericInstructionKind;
+
 export type MemoryInstructionKind = keyof typeof memoryInstructions;
 
 export const getControlInstructionKinds = () => Object.keys(controlInstructions) as readonly ControlInstructionKind[];
+
 export const getVariableInstructionKinds = () =>
   Object.keys(variableInstructions) as readonly VariableInstructionKind[];
+
 export const getInt32NumericInstructionKinds = () =>
   Object.keys(i32NumberInstructions) as readonly Int32NumericInstructionKind[];
+
+export const getInt64NumericInstructionKinds = () =>
+  Object.keys(i64NumberInstructions) as readonly Int64NumericInstructionKind[];
+
+export const getFloat32NumericInstructionKinds = () =>
+  Object.keys(f32NumberInstructions) as readonly Float32NumericInstructionKind[];
+
+export const getFloat64NumericInstructionKinds = () =>
+  Object.keys(f64NumberInstructions) as readonly Float64NumericInstructionKind[];
 
 export const getMemoryInstructionKinds = () => Object.keys(memoryInstructions) as readonly MemoryInstructionKind[];

--- a/src/wasm/instructions-map.ts
+++ b/src/wasm/instructions-map.ts
@@ -148,11 +148,28 @@ export const f64NumberInstructions = {
 
 export const memoryInstructions = {
   "i32.load": { code: 0x28, defaultAlign: 2 },
+  "i64.load": { code: 0x29, defaultAlign: 3 },
+  "f32.load": { code: 0x2a, defaultAlign: 2 },
+  "f64.load": { code: 0x2b, defaultAlign: 3 },
   "i32.load8_s": { code: 0x2c, defaultAlign: 0 },
   "i32.load8_u": { code: 0x2d, defaultAlign: 0 },
+  "i32.load16_s": { code: 0x2e, defaultAlign: 0 },
+  "i32.load16_u": { code: 0x2f, defaultAlign: 0 },
+  "i64.load8_s": { code: 0x30, defaultAlign: 0 },
+  "i64.load8_u": { code: 0x31, defaultAlign: 0 },
+  "i64.load16_s": { code: 0x32, defaultAlign: 0 },
+  "i64.load16_u": { code: 0x33, defaultAlign: 0 },
+  "i64.load32_s": { code: 0x34, defaultAlign: 0 },
+  "i64.load32_u": { code: 0x35, defaultAlign: 0 },
   "i32.store": { code: 0x36, defaultAlign: 2 },
+  "i64.store": { code: 0x37, defaultAlign: 3 },
+  "f32.store": { code: 0x38, defaultAlign: 2 },
+  "f64.store": { code: 0x39, defaultAlign: 3 },
   "i32.store8": { code: 0x3a, defaultAlign: 0 },
   "i32.store16": { code: 0x3b, defaultAlign: 0 },
+  "i64.store8": { code: 0x3c, defaultAlign: 0 },
+  "i64.store16": { code: 0x3d, defaultAlign: 0 },
+  "i64.store64": { code: 0x3e, defaultAlign: 0 },
 } as const;
 
 export const numberInstructions = {

--- a/src/wasm/structure-types.ts
+++ b/src/wasm/structure-types.ts
@@ -1,6 +1,6 @@
 import {
   VariableInstructionKind,
-  NumericInstructionKind,
+  Int32NumericInstructionKind,
   ControlInstructionKind,
   MemoryInstructionKind,
 } from "./instructions-map";
@@ -58,7 +58,7 @@ export interface VariableInstruction {
 
 export interface NumericInstruction {
   readonly kind: "NumericInstruction";
-  readonly instructionKind: NumericInstructionKind;
+  readonly instructionKind: Int32NumericInstructionKind;
   readonly parameters: readonly number[];
 }
 

--- a/src/wasm/structure-types.ts
+++ b/src/wasm/structure-types.ts
@@ -1,8 +1,8 @@
 import {
   VariableInstructionKind,
-  Int32NumericInstructionKind,
   ControlInstructionKind,
   MemoryInstructionKind,
+  NumericInstructionKind,
 } from "./instructions-map";
 
 export interface Int32Type {
@@ -58,7 +58,7 @@ export interface VariableInstruction {
 
 export interface NumericInstruction {
   readonly kind: "NumericInstruction";
-  readonly instructionKind: Int32NumericInstructionKind;
+  readonly instructionKind: NumericInstructionKind;
   readonly parameters: readonly number[];
 }
 

--- a/src/wasm/structure-types.ts
+++ b/src/wasm/structure-types.ts
@@ -9,7 +9,19 @@ export interface Int32Type {
   readonly kind: "Int32Type";
 }
 
-export type ValType = Int32Type;
+export interface Int64Type {
+  readonly kind: "Int64Type";
+}
+
+export interface Float32Type {
+  readonly kind: "Float32Type";
+}
+
+export interface Float64Type {
+  readonly kind: "Float64Type";
+}
+
+export type ValType = Int32Type | Int64Type | Float32Type | Float64Type;
 
 export type ResultType = readonly ValType[];
 

--- a/src/wasm/wat/parser.test.ts
+++ b/src/wasm/wat/parser.test.ts
@@ -27,7 +27,7 @@ describe(parseFuncSig, () => {
 });
 
 describe(parseIfInstr, () => {
-  const instr = f.numericInstr("i32.const", [f.int32(0)]);
+  const instr = f.int32NumericInstr("i32.const", [f.int32(0)]);
   test("success", () => {
     expect(use(parseIfInstr)("if (result i32) i32.const 0 else i32.const 0 end")).toMatchObject(
       f.ifInstr(f.blockType([f.valueType("i32")]), [instr], [instr]),
@@ -70,7 +70,7 @@ describe(parseVariableInstr, () => {
 
 describe(parseNumericInstr, () => {
   test("success", () => {
-    expect(use(parseNumericInstr)("i32.const 0")).toMatchObject(f.numericInstr("i32.const", [f.int32(0)]));
+    expect(use(parseNumericInstr)("i32.const 0")).toMatchObject(f.int32NumericInstr("i32.const", [f.int32(0)]));
   });
 });
 
@@ -108,7 +108,7 @@ describe(parseFunc, () => {
   test("success", () => {
     expect(use(parseFunc)("(func)")).toMatchObject(f.func(f.funcSig([], []), [], []));
     expect(use(parseFunc)("(func (result i32) i32.const 100)")).toMatchObject(
-      f.func(f.funcSig([], [f.valueType("i32")]), [], [f.numericInstr("i32.const", [f.int32(100)])]),
+      f.func(f.funcSig([], [f.valueType("i32")]), [], [f.int32NumericInstr("i32.const", [f.int32(100)])]),
     );
     expect(
       use(parseFunc)(
@@ -128,7 +128,7 @@ describe(parseFunc, () => {
         [
           f.variableInstr("local.get", [f.identifier("a")]),
           f.variableInstr("local.get", [f.identifier("b")]),
-          f.numericInstr("i32.add", []),
+          f.int32NumericInstr("i32.add", []),
         ],
         f.identifier("add"),
       ),
@@ -167,10 +167,14 @@ describe(parseMemory, () => {
 describe(parseGlobal, () => {
   test("success", () => {
     expect(use(parseGlobal)("(global i32 i32.const 0)")).toMatchObject(
-      f.globalNode(f.valueType("i32"), [f.numericInstr("i32.const", [f.int32(0)])]),
+      f.globalNode(f.valueType("i32"), [f.int32NumericInstr("i32.const", [f.int32(0)])]),
     );
     expect(use(parseGlobal)("(global $g (mut i32) i32.const 0)")).toMatchObject(
-      f.globalNode(f.mutValueType(f.valueType("i32")), [f.numericInstr("i32.const", [f.int32(0)])], f.identifier("g")),
+      f.globalNode(
+        f.mutValueType(f.valueType("i32")),
+        [f.int32NumericInstr("i32.const", [f.int32(0)])],
+        f.identifier("g"),
+      ),
     );
   });
 });
@@ -195,7 +199,7 @@ describe(parseExport, () => {
 describe(parseElem, () => {
   test("success", () => {
     expect(use(parseElem)("(elem (offset i32.const 0) func 0)")).toMatchObject(
-      f.elem(f.functionIndexList([f.uint32(0)]), [f.numericInstr("i32.const", [f.int32(0)])]),
+      f.elem(f.functionIndexList([f.uint32(0)]), [f.int32NumericInstr("i32.const", [f.int32(0)])]),
     );
   });
 });
@@ -208,7 +212,7 @@ describe(parseModule, () => {
     expect(use(parseModule)("(module (memory 1))")).toMatchObject(f.mod([mem]));
     expect(use(parseModule)("(module (memory 1) (type (func)))")).toMatchObject(f.mod([mem, typedef]));
     expect(use(parseModule)("(module (func (result i32) i32.const 1))")).toMatchObject(
-      f.mod([f.func(f.funcSig([], [f.valueType("i32")]), [], [f.numericInstr("i32.const", [f.int32(1)])])]),
+      f.mod([f.func(f.funcSig([], [f.valueType("i32")]), [], [f.int32NumericInstr("i32.const", [f.int32(1)])])]),
     );
   });
 });

--- a/src/wasm/wat/parser.test.ts
+++ b/src/wasm/wat/parser.test.ts
@@ -72,6 +72,15 @@ describe(parseNumericInstr, () => {
   test("success", () => {
     expect(use(parseNumericInstr)("i32.const 0")).toMatchObject(f.int32NumericInstr("i32.const", [f.int32(0)]));
   });
+  test("success", () => {
+    expect(use(parseNumericInstr)("i64.const 0")).toMatchObject(f.int64NumericInstr("i64.const", [f.int64(0)]));
+  });
+  test("success", () => {
+    expect(use(parseNumericInstr)("f32.const 0")).toMatchObject(f.float32NumericInstr("f32.const", [f.float32(0)]));
+  });
+  test("success", () => {
+    expect(use(parseNumericInstr)("f64.const 0")).toMatchObject(f.float64NumericInstr("f64.const", [f.float64(0)]));
+  });
 });
 
 describe(parseMemoryInstr, () => {

--- a/src/wasm/wat/parser.test.ts
+++ b/src/wasm/wat/parser.test.ts
@@ -97,7 +97,19 @@ describe(parseType, () => {
     expect(use(parseType)("(type (func (param i32)))")).toMatchObject(
       f.typedef(f.funcType([f.paramType(f.valueType("i32"))], [])),
     );
+    expect(use(parseType)("(type (func (param i64)))")).toMatchObject(
+      f.typedef(f.funcType([f.paramType(f.valueType("i64"))], [])),
+    );
+    expect(use(parseType)("(type (func (param f32)))")).toMatchObject(
+      f.typedef(f.funcType([f.paramType(f.valueType("f32"))], [])),
+    );
+    expect(use(parseType)("(type (func (param f64)))")).toMatchObject(
+      f.typedef(f.funcType([f.paramType(f.valueType("f64"))], [])),
+    );
     expect(use(parseType)("(type (func (result i32)))")).toMatchObject(f.typedef(f.funcType([], [f.valueType("i32")])));
+    expect(use(parseType)("(type (func (result i64)))")).toMatchObject(f.typedef(f.funcType([], [f.valueType("i64")])));
+    expect(use(parseType)("(type (func (result f32)))")).toMatchObject(f.typedef(f.funcType([], [f.valueType("f32")])));
+    expect(use(parseType)("(type (func (result f64)))")).toMatchObject(f.typedef(f.funcType([], [f.valueType("f64")])));
     expect(use(parseType)("(type (func (param i32) (result i32)))")).toMatchObject(
       f.typedef(f.funcType([f.paramType(f.valueType("i32"))], [f.valueType("i32")])),
     );
@@ -116,6 +128,7 @@ describe(parseType, () => {
 describe(parseFunc, () => {
   test("success", () => {
     expect(use(parseFunc)("(func)")).toMatchObject(f.func(f.funcSig([], []), [], []));
+    expect(use(parseFunc)("(func (result i64))")).toMatchObject(f.func(f.funcSig([], [f.valueType("i64")]), [], []));
     expect(use(parseFunc)("(func (result i32) i32.const 100)")).toMatchObject(
       f.func(f.funcSig([], [f.valueType("i32")]), [], [f.int32NumericInstr("i32.const", [f.int32(100)])]),
     );

--- a/src/wasm/wat/parser.ts
+++ b/src/wasm/wat/parser.ts
@@ -37,6 +37,7 @@ import {
   ElemNode,
   MutValueTypeNode,
   GlobalNode,
+  ValueTypeKind,
 } from "../ast-types";
 import { Scanner } from "./scanner";
 import {
@@ -105,10 +106,12 @@ const f64: Parser<Float64LiteralNode> = expect(decimalToken)(token => ({
 
 const index: Parser<IndexNode> = oneOf(identifier, u32);
 
-const valType: Parser<ValueTypeNode> = expect(keywordToken("i32"))(
+const valType: Parser<ValueTypeNode> = expect(
+  oneOf(keywordToken("i32"), keywordToken("i64"), keywordToken("f32"), keywordToken("f64")),
+)(
   (t): ValueTypeNode => ({
     kind: "ValueType",
-    valueKind: "i32",
+    valueKind: t.keyword as ValueTypeKind,
     ...loc(t),
   }),
 );
@@ -149,12 +152,12 @@ const result: Parser<ValueTypeNode> = tryWith(
   expect(
     symbolToken("("),
     keywordToken("result"),
-    keywordToken("i32"),
+    oneOf(keywordToken("i32"), keywordToken("i64"), keywordToken("f32"), keywordToken("f64")),
     symbolToken(")"),
   )(
     (tLp, tResult, tVk, tRp): ValueTypeNode => ({
       kind: "ValueType",
-      valueKind: "i32",
+      valueKind: tVk.keyword as ValueTypeKind,
       ...loc(tLp, tResult, tVk, tRp),
     }),
   ),

--- a/src/wasm/wat/parser.ts
+++ b/src/wasm/wat/parser.ts
@@ -13,6 +13,7 @@ import {
   ValueTypeNode,
   FuncSigNode,
   IndexNode,
+  Int32NumericInstructionNode,
   NumericInstructionNode,
   VariableInstructionNode,
   InstructionNode,
@@ -45,7 +46,7 @@ import {
 import {
   getControlInstructionKinds,
   getVariableInstructionKinds,
-  getNumericInstructionKinds,
+  getInt32NumericInstructionKinds,
   getMemoryInstructionKinds,
 } from "../instructions-map";
 
@@ -269,11 +270,11 @@ const variableInstr: Parser<VariableInstructionNode> = tryWith(
 
 const numericInstr: Parser<NumericInstructionNode> = tryWith(
   expect(
-    keywordsToken(getNumericInstructionKinds()),
+    keywordsToken(getInt32NumericInstructionKinds()),
     vec(i32),
   )(
-    (tInstrKind, params): NumericInstructionNode => ({
-      kind: "NumericInstruction",
+    (tInstrKind, params): Int32NumericInstructionNode => ({
+      kind: "Int32NumericInstruction",
       instructionKind: tInstrKind.keyword,
       parameters: params.values,
       ...loc(tInstrKind, params),

--- a/src/wasm/wat/tokenizer.test.ts
+++ b/src/wasm/wat/tokenizer.test.ts
@@ -1,6 +1,29 @@
 import { Scanner } from "../../parser-util";
-import { strToken } from "./tokenizer";
-import { StringToken } from "../ast-types";
+import { decimalToken, strToken } from "./tokenizer";
+import { StringToken, DecimalToken } from "../ast-types";
+
+test(decimalToken.name, () => {
+  expect(decimalToken(new Scanner("0")).unwrap()).toMatchObject<DecimalToken>({
+    tokenKind: "Decimal",
+    value: 0,
+  });
+  expect(decimalToken(new Scanner("0.")).unwrap()).toMatchObject<DecimalToken>({
+    tokenKind: "Decimal",
+    value: 0,
+  });
+  expect(decimalToken(new Scanner("0.1")).unwrap()).toMatchObject<DecimalToken>({
+    tokenKind: "Decimal",
+    value: 0.1,
+  });
+  expect(decimalToken(new Scanner("+0.1")).unwrap()).toMatchObject<DecimalToken>({
+    tokenKind: "Decimal",
+    value: 0.1,
+  });
+  expect(decimalToken(new Scanner("-0.1")).unwrap()).toMatchObject<DecimalToken>({
+    tokenKind: "Decimal",
+    value: -0.1,
+  });
+});
 
 test(strToken.name, () => {
   expect(strToken(new Scanner('""')).unwrap()).toMatchObject<StringToken>({

--- a/src/wasm/wat/tokenizer.ts
+++ b/src/wasm/wat/tokenizer.ts
@@ -8,6 +8,7 @@ import {
   IdentifierToken,
   IntToken,
   StringToken,
+  DecimalToken,
 } from "../ast-types";
 
 export const symbolToken: (sym: SymbolKind) => Parser<SymbolToken> = sym => {
@@ -96,6 +97,23 @@ const intTokenGen =
 
 export const intToken = intTokenGen(true);
 export const uintToken = intTokenGen(false);
+
+export const decimalToken: Parser<DecimalToken> = scanner => {
+  const intPart = scanner.match(/^([\+-]?\d+)/);
+  if (!intPart)
+    return error({
+      confirmed: false,
+      message: "Decimal number expected.",
+      occurence: { loc: { pos: scanner.pos, end: scanner.pos + 1 } },
+    });
+  const fractionHit = scanner.match(/^(\.\d*)/, intPart[1].length);
+  const str = intPart[1] + (fractionHit ? fractionHit[1] : "");
+  return ok({
+    tokenKind: "Decimal",
+    value: parseFloat(str),
+    loc: scanner.consume(str.length),
+  });
+};
 
 export const strToken: Parser<StringToken> = scanner => {
   if (!scanner.startsWith('"')) {

--- a/src/wasm/wat/unparser.test.ts
+++ b/src/wasm/wat/unparser.test.ts
@@ -40,6 +40,27 @@ const fixtures = [
   `,
   `
   (module
+    (func $main (result i64)
+      i64.const 20
+    )
+  )
+  `,
+  `
+  (module
+    (func $main (result f32)
+      f32.const 1.5
+    )
+  )
+  `,
+  `
+  (module
+    (func $main (result f64)
+      f64.const 1.5
+    )
+  )
+  `,
+  `
+  (module
     (func $main (param $a i32) (result i32)
       local.get $a
     )

--- a/src/wasm/wat/unparser.ts
+++ b/src/wasm/wat/unparser.ts
@@ -222,7 +222,7 @@ function unparseExpr(node: ExprNode, writer: Writer) {
     switch (instr.kind) {
       case "IfInstruction":
         return unparseIfInstr(instr, writer);
-      case "NumericInstruction":
+      case "Int32NumericInstruction":
         return unparseNumericInstr(instr, writer);
       case "ControlInstruction":
         return unparseControlInstr(instr, writer);

--- a/src/wasm/wat/unparser.ts
+++ b/src/wasm/wat/unparser.ts
@@ -3,6 +3,7 @@ import {
   ModuleNode,
   ModuleBodyNode,
   ParamTypeNode,
+  NumberLiteral,
   TypeNode,
   IdentifierNode,
   FuncTypeNode,
@@ -10,8 +11,6 @@ import {
   FuncNode,
   FuncSigNode,
   IndexNode,
-  Uint32LiteralNode,
-  Int32LiteralNode,
   LocalVarNode,
   ExprNode,
   NumericInstructionNode,
@@ -102,7 +101,7 @@ class Writer {
   }
 }
 
-function unparseInt(node: Uint32LiteralNode | Int32LiteralNode, writer: Writer) {
+function unparseInt(node: NumberLiteral, writer: Writer) {
   writer.append(`${node.value}`);
 }
 

--- a/src/wasm/wat/unparser.ts
+++ b/src/wasm/wat/unparser.ts
@@ -222,6 +222,9 @@ function unparseExpr(node: ExprNode, writer: Writer) {
       case "IfInstruction":
         return unparseIfInstr(instr, writer);
       case "Int32NumericInstruction":
+      case "Int64NumericInstruction":
+      case "Float32NumericInstruction":
+      case "Float64NumericInstruction":
         return unparseNumericInstr(instr, writer);
       case "ControlInstruction":
         return unparseControlInstr(instr, writer);


### PR DESCRIPTION
Add double precision floating number value type. They are represented with `f64` WASM value type.

And I fixed comparison operators, `<`, `>`, `<=` and `>=` . In the original OCaml spec, they work *polymorphic* . https://www2.lib.uchicago.edu/keith/ocaml-class/operators.html#compare .

I've changed compiler for these operator to accept various kind value types such as:

```ocaml
1 < 2
false < true
1.0 < 3.14
1::[] < 2::[]
```
