### PR TITLE
feat: Gather primary type for each expression node

### DIFF
--- a/playground/src/components/app-header/index.tsx
+++ b/playground/src/components/app-header/index.tsx
@@ -8,6 +8,7 @@ type Props = {
 };
 
 export function AppHeader({ className }: Props) {
+  const [dispatchUsingInferredType, setDispatchUsingInferredType] = useSettingsValue("dispatchUsingInferredType");
   const [enableNameSection, setenableNameSection] = useSettingsValue("enableNameSection");
   const [settingsIsOpening, setSettingsIsOpening] = useState(false);
   const closeCb = useCallback(() => setSettingsIsOpening(false), []);
@@ -32,12 +33,26 @@ export function AppHeader({ className }: Props) {
                 <label>
                   <input
                     type="checkbox"
+                    checked={dispatchUsingInferredType}
+                    onChange={() => setDispatchUsingInferredType(!dispatchUsingInferredType)}
+                  />
+                  <span>Static Dispatch</span>
+                </label>
+                <p>
+                  If enabled, compilation of some polymorphic operations will be optimized using inferred type
+                  statically.
+                </p>
+              </div>
+              <div className={styles.settingItem}>
+                <label>
+                  <input
+                    type="checkbox"
                     checked={enableNameSection}
                     onChange={() => setenableNameSection(!enableNameSection)}
                   />
                   <span>Emit WASM name section</span>
                 </label>
-                <p>If enabled, the names of functions or variables are refrected to Chrome devtool. </p>
+                <p>If enabled, the names of functions or variables are reflected to Chrome devtool. </p>
               </div>
             </div>
           )}

--- a/playground/src/components/ast-viewer/index.tsx
+++ b/playground/src/components/ast-viewer/index.tsx
@@ -5,7 +5,7 @@ import { JsonViewer } from "../json";
 import { useProgramStream } from "../../hooks/use-program-stream";
 
 export function AstViewer() {
-  const astResult = useProgramStream("parseResult$");
+  const astResult = useProgramStream("ast$");
   const selectedNodeResult = useProgramStream("selectedAstNode$");
   const shouldCollapse = (field: CollapsedFieldProps) => {
     const { _nodeId } = field.src as any as { readonly _nodeId: string };

--- a/playground/src/service/program.ts
+++ b/playground/src/service/program.ts
@@ -190,8 +190,13 @@ export function createProgram({ code$, settingsService }: CreateProgramOptions) 
     map(([pr, tvmr]) => createExtendedAstTree(pr, tvmr)),
     share(),
   );
-  const compileResult$ = combineLatest(parseResult$, primaryType$).pipe(
-    map(([pr, ptr]) => mapValue(pr, ptr)(expression => compile(expression))),
+  const compileResult$ = combineLatest(parseResult$, typeValueMap$, settingsService.settings$).pipe(
+    map(([pr, tvmr, { dispatchUsingInferredType }]) =>
+      mapValue(
+        pr,
+        tvmr,
+      )((expression, typeValueMap) => compile(expression, { typeValueMap, dispatchUsingInferredType })),
+    ),
     share(),
   );
   const wat$ = compileResult$.pipe(

--- a/playground/src/service/program.ts
+++ b/playground/src/service/program.ts
@@ -94,7 +94,36 @@ function createFormatter(instance: WebAssembly.Instance, pt: TypeValue): (value:
   throw new Error(`${pt.kind}`);
 }
 
-const forEachChild = createVisitorFunctions(mlVisitorKeys).forEachChild;
+const typePrinter = createTypePrinter();
+
+const { forEachChild, visitEachChild } = createVisitorFunctions(mlVisitorKeys);
+
+type ExtendedExpressionNode = ExpressionNode & {
+  typeInfo?: string;
+};
+
+function createExtendedAstTree(
+  parseResult: ParseResult<ExpressionNode>,
+  typeMapResult: Result<Map<string, TypeValue>, ParseError | TypeError>,
+) {
+  return parseResult.map(rootNode => {
+    if (!typeMapResult.ok) {
+      return rootNode;
+    }
+    const typeMap = typeMapResult.value;
+    const visitor = (node: ExpressionNode): ExtendedExpressionNode => {
+      const x = visitEachChild(node, visitor);
+      if (!node._nodeId) return x;
+      const typeValue = typeMap.get(node._nodeId);
+      if (!typeValue) return x;
+      return {
+        typeInfo: typePrinter(typeValue),
+        ...x,
+      };
+    };
+    return visitor(rootNode);
+  });
+}
 
 export interface Location {
   readonly line: number;
@@ -109,6 +138,8 @@ export interface Program {
   readonly selectedAstNode$: Observable<Result<{ readonly path: string[]; readonly found: Node | null }>>;
   readonly parseResult$: Observable<ParseResult<ExpressionNode>>;
   readonly primaryType$: Observable<Result<TypeValue, ParseError | TypeError>>;
+  readonly ast$: Observable<Result<ExtendedExpressionNode, ParseError>>;
+  readonly typeValueMap$: Observable<Result<Map<string, TypeValue>, ParseError | TypeError>>;
   readonly diagnostics$: Observable<readonly Diagnostic[]>;
   readonly wat$: Observable<Result<string>>;
   readonly wasm$: Observable<Result<Uint8Array>>;
@@ -149,13 +180,15 @@ export function createProgram({ code$, settingsService }: CreateProgramOptions) 
     share(),
   );
 
-  const primaryType$ = parseResult$.pipe(
-    map(pr =>
-      pr
-        .error(err => ({ ...err, messageWithTypes: undefined }))
-        .mapValue(getPrimaryType)
-        .map(({ expressionType }) => expressionType),
-    ),
+  const primaryTypeResult$ = parseResult$.pipe(
+    map(pr => pr.error(err => ({ ...err, messageWithTypes: undefined })).mapValue(getPrimaryType)),
+    share(),
+  );
+  const typeValueMap$ = primaryTypeResult$.pipe(map(ptr => ptr.map(v => v.typeValueMap)));
+  const primaryType$ = primaryTypeResult$.pipe(map(ptr => ptr.map(v => v.rootPrimaryType.expressionType)));
+  const ast$ = combineLatest(parseResult$, typeValueMap$).pipe(
+    map(([pr, tvmr]) => createExtendedAstTree(pr, tvmr)),
+    share(),
   );
   const compileResult$ = combineLatest(parseResult$, primaryType$).pipe(
     map(([pr, ptr]) => mapValue(pr, ptr)(expression => compile(expression))),
@@ -172,7 +205,7 @@ export function createProgram({ code$, settingsService }: CreateProgramOptions) 
     map(([code, ptr]) => {
       if (!ptr.ok) {
         const { line, character } = pos2location(code, ptr.value.occurence.loc!.pos);
-        const text = ptr.value.messageWithTypes ? ptr.value.messageWithTypes(createTypePrinter()) : ptr.value.message;
+        const text = ptr.value.messageWithTypes ? ptr.value.messageWithTypes(typePrinter) : ptr.value.message;
         const diagnostic: Diagnostic = {
           type: "error",
           text,
@@ -210,6 +243,8 @@ export function createProgram({ code$, settingsService }: CreateProgramOptions) 
     selection$,
     selectedAstNode$,
     parseResult$,
+    typeValueMap$,
+    ast$,
     primaryType$,
     diagnostics$,
     wat$,

--- a/playground/src/service/settings.ts
+++ b/playground/src/service/settings.ts
@@ -1,7 +1,7 @@
 import { Observable, BehaviorSubject } from "rxjs";
-import { BinaryOutputOptions } from "pico-ml";
+import { OutputOptions } from "pico-ml";
 
-export type SettingsOptions = BinaryOutputOptions;
+export type SettingsOptions = OutputOptions;
 
 type PartialOptions = { [K in keyof SettingsOptions]?: boolean };
 
@@ -12,6 +12,7 @@ export interface SettingsService {
 
 export const defaultSettingOptions: SettingsOptions = {
   enableNameSection: true,
+  dispatchUsingInferredType: true,
 };
 
 export function createSettingsService(): SettingsService {

--- a/src/cli/repl.ts
+++ b/src/cli/repl.ts
@@ -114,8 +114,8 @@ function evaluateExpression(code: string, reporter: ErrorReporter) {
     return;
   }
 
-  const typePrinter = createTypePrinter({ remapWithSubstitutions: typeResult.value.substitutions });
-  const typeStr = typePrinter(typeResult.value.expressionType);
+  const typePrinter = createTypePrinter({ remapWithSubstitutions: typeResult.value.rootPrimaryType.substitutions });
+  const typeStr = typePrinter(typeResult.value.rootPrimaryType.expressionType);
   process.stdout.write(`${color.yellow("==> ")}${typeStr}: `);
 
   // evaluation

--- a/src/compiler/assets/modules/comparator.ts
+++ b/src/compiler/assets/modules/comparator.ts
@@ -243,3 +243,15 @@ export function getComparatorModuleDefinition({
 export function compareInstr(op: ComparisonOperators) {
   return [factory.controlInstr("call", [factory.identifier(`__comparator_poly_${op}__`)])];
 }
+
+export function intCompareInstr(op: ComparisonOperators) {
+  if (op !== "eq") {
+    return [factory.int32NumericInstr(`i32.${op}_s`)];
+  } else {
+    return [factory.int32NumericInstr("i32.eq")];
+  }
+}
+
+export function floatCompareInstr(op: ComparisonOperators) {
+  return [factory.float64NumericInstr(`f64.${op}`)];
+}

--- a/src/compiler/compile-node/binary-expression.ts
+++ b/src/compiler/compile-node/binary-expression.ts
@@ -1,115 +1,118 @@
-import { mapValue, ok, error, Result } from "../../structure";
-import { BinaryOperation } from "../../syntax";
-import { CompileNodeFn, CompilationValue, CompilationContext } from "../types";
-import { factory, InstructionNode } from "../../wasm";
-import { getFloatValueInstr, storeFloatValueInstr } from "../assets/modules/float";
-import { compareInstr } from "../assets/modules/comparator";
+import { mapValue, ok, error } from "../../structure";
 
-function getOperationInstr(
-  left: CompilationValue,
-  right: CompilationValue,
-  op: BinaryOperation,
-  ctx: CompilationContext,
-): Result<readonly InstructionNode[]> {
-  switch (op.kind) {
-    case "Add":
-      // 2(a + b) + 1 = (2a + 1) + (2b + 1) - 1 = A + B - 1
-      return ok([
-        ...left,
-        ...right,
-        factory.int32NumericInstr("i32.add", []),
-        factory.int32NumericInstr("i32.const", [factory.int32(1)]),
-        factory.int32NumericInstr("i32.sub", []),
-      ]);
-    case "Sub":
-      // 2(a - b) + 1 = (2a + 1) - (2b + 1) + 1 = A - B + 1
-      return ok([
-        ...left,
-        ...right,
-        factory.int32NumericInstr("i32.sub", []),
-        factory.int32NumericInstr("i32.const", [factory.int32(1)]),
-        factory.int32NumericInstr("i32.add", []),
-      ]);
-    case "Multiply": {
-      // 2ab + 1 = (2a + 1 - 1) * b  + 1 = (A - 1) * (B >> 1) + 1
-      return ok([
-        ...left,
-        factory.int32NumericInstr("i32.const", [factory.int32(1)]),
-        factory.int32NumericInstr("i32.sub", []),
-        ...right,
-        factory.int32NumericInstr("i32.const", [factory.int32(1)]),
-        factory.int32NumericInstr("i32.shr_s", []),
-        factory.int32NumericInstr("i32.mul", []),
-        factory.int32NumericInstr("i32.const", [factory.int32(1)]),
-        factory.int32NumericInstr("i32.add", []),
-      ]);
-    }
-    case "Or":
-      return ok([...left, ...right, factory.int32NumericInstr("i32.or", [])]);
-    case "And":
-      return ok([...left, ...right, factory.int32NumericInstr("i32.and", [])]);
-    case "LessThan": {
-      ctx.useComparator("lt");
-      return ok([...left, ...right, ...compareInstr("lt")]);
-    }
-    case "LessEqualThan": {
-      ctx.useComparator("le");
-      return ok([...left, ...right, ...compareInstr("le")]);
-    }
-    case "GreaterThan": {
-      ctx.useComparator("gt");
-      return ok([...left, ...right, ...compareInstr("gt")]);
-    }
-    case "GreaterEqualThan": {
-      ctx.useComparator("ge");
-      return ok([...left, ...right, ...compareInstr("ge")]);
-    }
-    case "Equal":
-      return ok([...left, ...right, factory.int32NumericInstr("i32.eq", [])]);
-    case "NotEqual":
-      return ok([...left, ...right, factory.int32NumericInstr("i32.ne", [])]);
-    case "FAdd": {
-      ctx.useFloat();
-      return ok([
-        ...left,
-        ...getFloatValueInstr(),
-        ...right,
-        ...getFloatValueInstr(),
-        factory.float64NumericInstr("f64.add", []),
-        ...storeFloatValueInstr(),
-      ]);
-    }
-    case "FSub": {
-      ctx.useFloat();
-      return ok([
-        ...left,
-        ...getFloatValueInstr(),
-        ...right,
-        ...getFloatValueInstr(),
-        factory.float64NumericInstr("f64.sub", []),
-        ...storeFloatValueInstr(),
-      ]);
-    }
-    case "FMultiply": {
-      ctx.useFloat();
-      return ok([
-        ...left,
-        ...getFloatValueInstr(),
-        ...right,
-        ...getFloatValueInstr(),
-        factory.float64NumericInstr("f64.mul", []),
-        ...storeFloatValueInstr(),
-      ]);
-    }
-    default:
-      // @ts-expect-error
-      return error({ message: `invalid kind: ${op.kind}` });
-  }
-}
+import { CompileNodeFn } from "../types";
+import { factory } from "../../wasm";
+import { getFloatValueInstr, storeFloatValueInstr } from "../assets/modules/float";
+import { compareInstr, intCompareInstr, floatCompareInstr, ComparisonOperators } from "../assets/modules/comparator";
 
 export const binaryExpression: CompileNodeFn<"BinaryExpression"> = (node, ctx, next) => {
+  const { typeValueMap, dispatchUsingInferredType } = ctx.getOptions();
+  const lType = node.left._nodeId ? typeValueMap.get(node.left._nodeId) : undefined;
+  const rType = node.right._nodeId ? typeValueMap.get(node.right._nodeId) : undefined;
+  const isOperandInferredInt =
+    !!dispatchUsingInferredType &&
+    (lType?.kind === "Bool" || lType?.kind === "Int" || rType?.kind === "Bool" || rType?.kind === "Int");
+  const isOperandInferredFloat = !!dispatchUsingInferredType && (lType?.kind === "Float" || rType?.kind === "Float");
   return mapValue(
     next(node.left, ctx),
     next(node.right, ctx),
-  )((left, right) => getOperationInstr(left, right, node.op, ctx).error(err => ({ ...err, occurence: node })));
+  )((left, right) => {
+    const dispatchCompareInstr = (op: ComparisonOperators) => {
+      if (isOperandInferredInt) {
+        return ok([...left, ...right, ...intCompareInstr(op)]);
+      } else if (isOperandInferredFloat) {
+        ctx.useFloat();
+        return ok([...left, ...getFloatValueInstr(), ...right, ...getFloatValueInstr(), ...floatCompareInstr(op)]);
+      } else {
+        ctx.useComparator(op);
+        return ok([...left, ...right, ...compareInstr(op)]);
+      }
+    };
+    switch (node.op.kind) {
+      case "Add":
+        // 2(a + b) + 1 = (2a + 1) + (2b + 1) - 1 = A + B - 1
+        return ok([
+          ...left,
+          ...right,
+          factory.int32NumericInstr("i32.add", []),
+          factory.int32NumericInstr("i32.const", [factory.int32(1)]),
+          factory.int32NumericInstr("i32.sub", []),
+        ]);
+      case "Sub":
+        // 2(a - b) + 1 = (2a + 1) - (2b + 1) + 1 = A - B + 1
+        return ok([
+          ...left,
+          ...right,
+          factory.int32NumericInstr("i32.sub", []),
+          factory.int32NumericInstr("i32.const", [factory.int32(1)]),
+          factory.int32NumericInstr("i32.add", []),
+        ]);
+      case "Multiply": {
+        // 2ab + 1 = (2a + 1 - 1) * b  + 1 = (A - 1) * (B >> 1) + 1
+        return ok([
+          ...left,
+          factory.int32NumericInstr("i32.const", [factory.int32(1)]),
+          factory.int32NumericInstr("i32.sub", []),
+          ...right,
+          factory.int32NumericInstr("i32.const", [factory.int32(1)]),
+          factory.int32NumericInstr("i32.shr_s", []),
+          factory.int32NumericInstr("i32.mul", []),
+          factory.int32NumericInstr("i32.const", [factory.int32(1)]),
+          factory.int32NumericInstr("i32.add", []),
+        ]);
+      }
+      case "Or":
+        return ok([...left, ...right, factory.int32NumericInstr("i32.or", [])]);
+      case "And":
+        return ok([...left, ...right, factory.int32NumericInstr("i32.and", [])]);
+      case "LessThan":
+        return dispatchCompareInstr("lt");
+      case "LessEqualThan":
+        return dispatchCompareInstr("le");
+      case "GreaterThan":
+        return dispatchCompareInstr("gt");
+      case "GreaterEqualThan":
+        return dispatchCompareInstr("ge");
+      case "Equal":
+        return ok([...left, ...right, factory.int32NumericInstr("i32.eq", [])]);
+      case "NotEqual":
+        return ok([...left, ...right, factory.int32NumericInstr("i32.ne", [])]);
+      case "FAdd": {
+        ctx.useFloat();
+        return ok([
+          ...left,
+          ...getFloatValueInstr(),
+          ...right,
+          ...getFloatValueInstr(),
+          factory.float64NumericInstr("f64.add", []),
+          ...storeFloatValueInstr(),
+        ]);
+      }
+      case "FSub": {
+        ctx.useFloat();
+        return ok([
+          ...left,
+          ...getFloatValueInstr(),
+          ...right,
+          ...getFloatValueInstr(),
+          factory.float64NumericInstr("f64.sub", []),
+          ...storeFloatValueInstr(),
+        ]);
+      }
+      case "FMultiply": {
+        ctx.useFloat();
+        return ok([
+          ...left,
+          ...getFloatValueInstr(),
+          ...right,
+          ...getFloatValueInstr(),
+          factory.float64NumericInstr("f64.mul", []),
+          ...storeFloatValueInstr(),
+        ]);
+      }
+      default:
+        // @ts-expect-error
+        return error({ message: `invalid kind: ${op.kind}` });
+    }
+  }).error(err => ({ ...err, occurence: node }));
 };

--- a/src/compiler/compiler-context.ts
+++ b/src/compiler/compiler-context.ts
@@ -1,5 +1,6 @@
 import { InstructionNode, LocalVarNode } from "../wasm";
-import { CompilationContext, Environment } from "./types";
+
+import { CompilationContext, Environment, CompileNodeOptions } from "./types";
 import { ModuleDefinition } from "./module-builder";
 import { getAllocatorModuleDefinition } from "./assets/modules/alloc";
 import { getFloatModuleDefinition } from "./assets/modules/float";
@@ -12,7 +13,7 @@ import { FunctionDefinitionStack } from "./function-definition-stack";
 import { MatcherDefinitionStack } from "./matcher-definition-stack";
 import { getComparatorModuleDefinition } from "./assets/modules/comparator";
 
-export class Context implements CompilationContext {
+export class Context implements CompilationContext<CompileNodeOptions> {
   private _env: Environment = createRootEnvironment();
   private _instructions: InstructionNode[] = [];
   private _enabledAllocator = false;
@@ -29,7 +30,11 @@ export class Context implements CompilationContext {
   public readonly funcDefStack = new FunctionDefinitionStack();
   public readonly matcherDefStack = new MatcherDefinitionStack();
 
-  constructor() {}
+  constructor(private readonly _options: CompileNodeOptions = { typeValueMap: new Map() }) {}
+
+  getOptions() {
+    return this._options;
+  }
 
   pushInstruction(instruction: InstructionNode | readonly InstructionNode[]) {
     if (Array.isArray(instruction)) {
@@ -116,7 +121,8 @@ export class Context implements CompilationContext {
     this._dependencies.push(getMatcherModuleDefinition());
   }
 
-  useComparator(op: "lt" | "le" | "gt" | "ge") {
+  useComparator(op: "lt" | "le" | "gt" | "ge" | "eq") {
+    if (op === "eq") return;
     this._enableComparator = true;
     this._includingComparisonOperators = [...new Set([...this._includingComparisonOperators, op])];
   }

--- a/src/compiler/compiler.ts
+++ b/src/compiler/compiler.ts
@@ -1,7 +1,8 @@
 import { createTreeTraverser } from "../structure";
 import { factory } from "../wasm";
 import { ExpressionNode } from "../syntax";
-import { CompilationContext, CompilationResult, CompiledModuleResult } from "./types";
+
+import { CompilationContext, CompilationResult, CompiledModuleResult, CompileNodeOptions } from "./types";
 import { Context } from "./compiler-context";
 import { ModuleBuilder } from "./module-builder";
 
@@ -20,7 +21,7 @@ import { functionApplication } from "./compile-node/function-application";
 import { letExpression } from "./compile-node/let-expression";
 import { letRecExpression } from "./compile-node/let-rec-expression";
 
-const traverse = createTreeTraverser<ExpressionNode, CompilationContext, CompilationResult>({
+const traverse = createTreeTraverser<ExpressionNode, CompilationContext<CompileNodeOptions>, CompilationResult>({
   boolLiteral,
   emptyList,
   intLiteral,
@@ -37,8 +38,11 @@ const traverse = createTreeTraverser<ExpressionNode, CompilationContext, Compila
   letRecExpression,
 });
 
-export function compile(node: ExpressionNode): CompiledModuleResult {
-  const ctx = new Context();
+export function compile(
+  node: ExpressionNode,
+  options: CompileNodeOptions = { dispatchUsingInferredType: true, typeValueMap: new Map() },
+): CompiledModuleResult {
+  const ctx = new Context(options);
   return traverse(node, ctx).mapValue(instructions => {
     const mainFunc = factory.func(
       factory.funcSig([], [factory.valueType("i32")]),

--- a/src/compiler/index.ts
+++ b/src/compiler/index.ts
@@ -1,2 +1,3 @@
 export { compile } from "./compiler";
 export * from "./js-bindings";
+export { CompileNodeOptions } from "./types";

--- a/src/compiler/types.ts
+++ b/src/compiler/types.ts
@@ -1,6 +1,7 @@
 import { Result, ResultErrorBase, TraverserCallbackFn } from "../structure";
 import { Position } from "../parser-util";
 import { ExpressionNode, IdentifierNode } from "../syntax";
+import { TypeValue } from "../type-checker";
 import { ModuleNode, InstructionNode, ExprNode, LocalVarNode, IdentifierNode as WATIdNode } from "../wasm";
 
 export interface CompilationError extends ResultErrorBase {
@@ -8,6 +9,11 @@ export interface CompilationError extends ResultErrorBase {
 }
 
 export type CompilationValue = readonly InstructionNode[];
+
+export interface CompileNodeOptions {
+  readonly typeValueMap: Map<string, TypeValue>;
+  readonly dispatchUsingInferredType?: boolean;
+}
 
 export type CompiledModuleResult = Result<ModuleNode, CompilationError>;
 export type CompilationResult = Result<CompilationValue, CompilationError>;
@@ -21,7 +27,8 @@ export interface DefinitionStack<T, S = number> {
   readonly leave: (param: T) => S;
 }
 
-export interface CompilationContext {
+export interface CompilationContext<T extends {} = {}> {
+  readonly getOptions: () => T;
   readonly pushInstruction: (instruction: InstructionNode | readonly InstructionNode[]) => void;
   readonly useAllocator: () => void;
   readonly useFloat: () => void;
@@ -29,7 +36,7 @@ export interface CompilationContext {
   readonly useTuple: () => void;
   readonly useEnvironment: () => void;
   readonly useMatcher: () => void;
-  readonly useComparator: (op: "lt" | "le" | "gt" | "ge") => void;
+  readonly useComparator: (op: "lt" | "le" | "gt" | "ge" | "eq") => void;
   readonly useLocalVar: (node: LocalVarNode) => void;
   readonly setEnv: (env: Environment) => void;
   readonly getEnv: () => Environment;
@@ -41,7 +48,7 @@ export interface CompilationContext {
 
 export type CompileNodeFn<K extends ExpressionNode["kind"]> = TraverserCallbackFn<
   ExpressionNode,
-  CompilationContext,
+  CompilationContext<CompileNodeOptions>,
   CompilationResult,
   K
 >;

--- a/src/index.ts
+++ b/src/index.ts
@@ -6,5 +6,5 @@ export * from "./evaluate";
 export * from "./type-checker";
 export * from "./compiler";
 export * from "./string-util";
-export type { BinaryOutputOptions } from "./wasm";
 export { printAST, generateBinary } from "./wasm";
+export * from "./types";

--- a/src/type-checker/primary-type.test.ts
+++ b/src/type-checker/primary-type.test.ts
@@ -48,7 +48,9 @@ describe(getPrimaryType, () => {
   Object.keys(fixture).forEach(input => {
     test(`Primary type for: "${input}"`, () => {
       const expectedValue = (fixture as Record<string, () => string>)[input]();
-      const { expressionType, substitutions } = parse(input).mapValue(getPrimaryType).unwrap();
+      const {
+        rootPrimaryType: { expressionType, substitutions },
+      } = parse(input).mapValue(getPrimaryType).unwrap();
       const printer = createTypePrinter({ remapWithSubstitutions: substitutions });
       expect(printer(expressionType)).toBe(expectedValue);
     });

--- a/src/type-checker/primary-type.ts
+++ b/src/type-checker/primary-type.ts
@@ -1,5 +1,5 @@
 import { ExpressionNode } from "../syntax";
-import { PrimaryTypeNode, PrimaryTypeResult, PrimaryTypeContext } from "./types";
+import { PrimaryTypeResult, PrimaryTypeNode, PrimaryTypeNodeResult, PrimaryTypeContext, TypeValue } from "./types";
 import { createRootEnvironment, ParmGenerator } from "./type-environment";
 import { createTreeTraverser, TraverserCallbackFnMap } from "../structure/traverser";
 import { intLiteral } from "./pt-node/int-literal";
@@ -17,7 +17,7 @@ import { letExpression } from "./pt-node/let-expression";
 import { letRecExpression } from "./pt-node/let-rec-expression";
 import { functionApplication } from "./pt-node/function-application";
 
-type FunctionMap = TraverserCallbackFnMap<ExpressionNode, PrimaryTypeContext, PrimaryTypeResult>;
+type FunctionMap = TraverserCallbackFnMap<ExpressionNode, PrimaryTypeContext, PrimaryTypeNodeResult>;
 
 function wrapWithFunctionAfterTraverse(mapObj: FunctionMap): FunctionMap {
   const keys = Object.keys(mapObj) as (keyof FunctionMap)[];
@@ -36,8 +36,9 @@ function wrapWithFunctionAfterTraverse(mapObj: FunctionMap): FunctionMap {
   return ret;
 }
 
-export function getPrimaryType(expression: ExpressionNode) {
-  return createTreeTraverser<ExpressionNode, PrimaryTypeContext, PrimaryTypeResult>(
+export function getPrimaryType(expression: ExpressionNode): PrimaryTypeResult {
+  const ptMap = new Map<string, TypeValue>();
+  return createTreeTraverser<ExpressionNode, PrimaryTypeContext, PrimaryTypeNodeResult>(
     wrapWithFunctionAfterTraverse({
       intLiteral,
       floatLiteral,
@@ -57,6 +58,6 @@ export function getPrimaryType(expression: ExpressionNode) {
   )(expression, {
     generator: new ParmGenerator(),
     env: createRootEnvironment(),
-    ptMap: new Map(),
-  });
+    ptMap,
+  }).map(ptv => ({ rootPrimaryType: ptv, typeValueMap: ptMap }));
 }

--- a/src/type-checker/primary-type.ts
+++ b/src/type-checker/primary-type.ts
@@ -1,7 +1,7 @@
 import { ExpressionNode } from "../syntax";
-import { PrimaryTypeResult, PrimaryTypeContext } from "./types";
+import { PrimaryTypeNode, PrimaryTypeResult, PrimaryTypeContext } from "./types";
 import { createRootEnvironment, ParmGenerator } from "./type-environment";
-import { createTreeTraverser } from "../structure/traverser";
+import { createTreeTraverser, TraverserCallbackFnMap } from "../structure/traverser";
 import { intLiteral } from "./pt-node/int-literal";
 import { floatLiteral } from "./pt-node/float-literal";
 import { boolLiteral } from "./pt-node/bool-literal";
@@ -17,24 +17,46 @@ import { letExpression } from "./pt-node/let-expression";
 import { letRecExpression } from "./pt-node/let-rec-expression";
 import { functionApplication } from "./pt-node/function-application";
 
+type FunctionMap = TraverserCallbackFnMap<ExpressionNode, PrimaryTypeContext, PrimaryTypeResult>;
+
+function wrapWithFunctionAfterTraverse(mapObj: FunctionMap): FunctionMap {
+  const keys = Object.keys(mapObj) as (keyof FunctionMap)[];
+  const ret = {} as any;
+  for (const key of keys) {
+    const fn = mapObj[key] as PrimaryTypeNode<any>;
+    const wrapped: PrimaryTypeNode<any> = (node, ctx, next) => {
+      const result = fn(node, ctx, next);
+      if (result.ok && node._nodeId) {
+        ctx.ptMap?.set(node._nodeId, result.value.expressionType);
+      }
+      return result;
+    };
+    ret[key] = wrapped;
+  }
+  return ret;
+}
+
 export function getPrimaryType(expression: ExpressionNode) {
-  return createTreeTraverser<ExpressionNode, PrimaryTypeContext, PrimaryTypeResult>({
-    intLiteral,
-    floatLiteral,
-    boolLiteral,
-    emptyList,
-    identifier,
-    listConstructor,
-    unaryExpression,
-    binaryExpression,
-    functionDefinition,
-    ifExpression,
-    matchExpression,
-    letExpression,
-    letRecExpression,
-    functionApplication,
-  })(expression, {
+  return createTreeTraverser<ExpressionNode, PrimaryTypeContext, PrimaryTypeResult>(
+    wrapWithFunctionAfterTraverse({
+      intLiteral,
+      floatLiteral,
+      boolLiteral,
+      emptyList,
+      identifier,
+      listConstructor,
+      unaryExpression,
+      binaryExpression,
+      functionDefinition,
+      ifExpression,
+      matchExpression,
+      letExpression,
+      letRecExpression,
+      functionApplication,
+    }),
+  )(expression, {
     generator: new ParmGenerator(),
     env: createRootEnvironment(),
+    ptMap: new Map(),
   });
 }

--- a/src/type-checker/pt-node/_result.ts
+++ b/src/type-checker/pt-node/_result.ts
@@ -1,7 +1,7 @@
 import { useResult } from "../../structure";
-import { PrimaryTypeResult, TypeValue, TypeSubstitution } from "../types";
+import { PrimaryTypeNodeResult, TypeValue, TypeSubstitution } from "../types";
 
-const { ok: _ok, error } = useResult<PrimaryTypeResult>();
+const { ok: _ok, error } = useResult<PrimaryTypeNodeResult>();
 
 const ok = (type: TypeValue, substitutions: readonly TypeSubstitution[] = [] as const) =>
   _ok({

--- a/src/type-checker/types.ts
+++ b/src/type-checker/types.ts
@@ -73,11 +73,18 @@ export interface PrimaryTypeValue {
   readonly substitutions: readonly TypeSubstitution[];
   readonly expressionType: TypeValue;
 }
-export type PrimaryTypeResult = Result<PrimaryTypeValue, TypeError>;
+export type PrimaryTypeNodeResult = Result<PrimaryTypeValue, TypeError>;
 
 export type PrimaryTypeNode<K extends ExpressionNode["kind"]> = TraverserCallbackFn<
   ExpressionNode,
   PrimaryTypeContext,
-  PrimaryTypeResult,
+  PrimaryTypeNodeResult,
   K
 >;
+
+export interface PrimaryTypeResultValue {
+  readonly rootPrimaryType: PrimaryTypeValue;
+  readonly typeValueMap: Map<string, TypeValue>;
+}
+
+export type PrimaryTypeResult = Result<PrimaryTypeResultValue, TypeError>;

--- a/src/type-checker/types.ts
+++ b/src/type-checker/types.ts
@@ -48,6 +48,7 @@ export interface TypeParemeterGenerator {
 export interface PrimaryTypeContext {
   readonly generator: TypeParemeterGenerator;
   readonly env: TypeEnvironment;
+  readonly ptMap?: Map<string, TypeValue>;
 }
 
 export interface TypeEquation {

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,0 +1,4 @@
+import { CompileNodeOptions } from "./compiler";
+import { BinaryOutputOptions } from "./wasm";
+
+export interface OutputOptions extends BinaryOutputOptions, Omit<CompileNodeOptions, "typeValueMap"> {}

--- a/src/wasm/types.ts
+++ b/src/wasm/types.ts
@@ -1,3 +1,3 @@
 export interface BinaryOutputOptions {
-  readonly enableNameSection: boolean;
+  readonly enableNameSection?: boolean;
 }


### PR DESCRIPTION
### What I did

Add optimization procedure against polymorphic comparison operation (e.g. `<` ).

Almost, these comparison operators are used with operands whose type is statically fixed. 

For example:

```ocaml
(* the comparison expression works with only Int type values *)
fun n -> n <= 1
```

In these cases, we can statically decide and dispatch the comparison logic for the fixed type.

To achieve it, I add the following features:

- Core
  - A map object from expression node's ID to primary type of the node. The map object can be referred from compilation procedure
  - A new output option, `dispatchUsingInferredType`, allows to toggle to enable the optimization
- Playground
  - Show inferred type for user's selected expression to AST viewer